### PR TITLE
fix(worker): launch the auditor's pi child through the shell on Windows

### DIFF
--- a/scripts/goal-auditor-worker.mjs
+++ b/scripts/goal-auditor-worker.mjs
@@ -101,8 +101,16 @@ async function atomicJson(file, value) {
   try {
     await rename(temp, file);
   } catch (error) {
-    await rm(temp, { force: true }).catch(() => {});
-    throw error;
+    // Windows may refuse to replace a file that a concurrent reader or an
+    // antivirus scanner briefly holds open. Unlink the old target and retry
+    // once before giving up.
+    try {
+      await rm(file, { force: true });
+      await rename(temp, file);
+    } catch (retryError) {
+      await rm(temp, { force: true }).catch(() => {});
+      throw retryError;
+    }
   }
 }
 
@@ -388,6 +396,13 @@ async function main() {
       cwd: request.cwd,
       env: process.env,
       stdio: ["pipe", "pipe", "pipe"],
+      // npm publishes platform shims (pi.cmd/pi.ps1) without a real pi.exe;
+      // plain spawn cannot launch a .cmd file, so route through the shell on
+      // Windows. POSIX keeps the direct exec (no shell injection surface).
+      // piArgs is plugin-constructed (fixed flags plus the model/thinking
+      // level from the audited goal), so the cmd concat is not attacker-
+      // controlled.
+      shell: process.platform === "win32",
     });
 
     const remaining = Math.max(1, request.wallDeadlineAt - Date.now());


### PR DESCRIPTION
Fixes #7

## Problem

On Windows the detached goal auditor never launches: `spawn("pi")` without `shell: true` cannot execute npm's `pi.cmd` shim (there is no `pi.exe`), so every audit job failed with `pi launch failed: spawn pi ENOENT` (0/76 successes on this machine). A secondary Windows issue: `atomicJson`'s `rename(temp, file)` can hit `EPERM` when the target is briefly held open (AV scanner / concurrent reader).

## Change

`scripts/goal-auditor-worker.mjs`:

1. **spawn**: `shell: process.platform === "win32"` — routes the RPC child through `cmd.exe` on Windows where npm ships shims only. POSIX keeps the direct exec (no shell injection surface). `piArgs` is plugin-constructed (fixed flags + the audited goal's model/thinking level), so the cmd concat is not attacker-controlled.
2. **atomicJson**: on `rename` failure, unlink the old target and retry once before giving up — tolerates the transient lock Windows can place on the destination file.

## Verification

- Baseline on Windows: `bun test` 55 pass / 112 fail / 103 errors **identical before and after this change** (all failures are pre-existing Windows/Bun environment issues — nested `test()` is unimplemented in Bun, `EBUSY` temp-file locks, POSIX-only shebang fixtures; the repo has no Windows CI).
- End-to-end on Windows with the patched worker: a real audit job launched the `pi --mode rpc` child, ran 40 read-only tool calls, and produced `ok: true` (previously it died in 31ms with ENOENT before doing anything).
- `node --check` and `tsc --noEmit` clean.

No test changes — the worker test harness is POSIX-only by design (`GLLA_PI_BINARY` points at a chmod'ed `.mjs` fixture), and this repo has no Windows CI where a regression test could run.