### PR TITLE
fix(auditor): launch pi via shell on Windows to resolve .cmd shim

### DIFF
--- a/scripts/goal-auditor-worker.mjs
+++ b/scripts/goal-auditor-worker.mjs
@@ -432,10 +432,17 @@ async function main() {
       "--model", request.model,
       "--thinking", request.thinkingLevel,
     ];
+    // On Windows the npm-installed `pi` entrypoint is a .cmd shim (there is no
+    // pi.exe), and Node's child_process cannot exec .cmd/.bat files without a
+    // shell — spawn("pi") → ENOENT, spawn("pi.cmd") → EINVAL. shell: true routes
+    // the launch through cmd.exe, which resolves the shim via PATH/PATHEXT.
+    // The RPC child's own stdin/stdout/stderr pipes are unaffected. Unix keeps
+    // the direct, shell-less spawn.
     pi = spawn(piBinary, piArgs, {
       cwd: request.cwd,
       env: process.env,
       stdio: ["pipe", "pipe", "pipe"],
+      ...(process.platform === "win32" ? { shell: true } : {}),
     });
 
     const remaining = Math.max(1, request.wallDeadlineAt - Date.now());


### PR DESCRIPTION
## Problem

On Windows, the detached completion auditor can never launch its RPC
session: every audit fails immediately with `pi launch failed: spawn pi
ENOENT`.

## Root cause

The npm-installed `pi` entrypoint has no `.exe` on Windows — npm only
ships `pi` / `pi.cmd` / `pi.ps1` shims. Node's `child_process.spawn`
(without a shell) cannot exec `.cmd`/`.bat` files:

- `spawn("pi")` → `ENOENT`
- `spawn("pi.cmd")` → `EINVAL`

`scripts/goal-auditor-worker.mjs` spawns `pi` directly, assuming a Unix
executable. Because the auditor verdict gates every goal/list/loop
completion, this leaves all three modes permanently stuck at "audit
queued → audit failed" on Windows.

## Fix

Add `shell: true` on `win32` so the launch routes through `cmd.exe`,
which resolves the `.cmd` shim via `PATH`/`PATHEXT`. Unix keeps the
existing direct, shell-less spawn.

## Verification

- Manual (Windows): `spawn("pi", ["--version"], { shell: true })`
  launches pi and exits 0, printing `0.84.1`.
- End-to-end worker test (Windows): running the worker against a fake-pi
  `.cmd` shim now parses the RPC stream and returns `ok: true` with the
  verdict, instead of `ENOENT`.

## Notes

- This triggers Node's `DEP0190` deprecation warning ("arguments are not
  escaped, only concatenated") when `shell: true` is combined with an args
  array. In production the worker is spawned with `stdio: "ignore"`, so
  the warning is discarded; the args are static flags plus a trusted
  model id / thinking level. Can be rewritten as an explicit
  `cmd.exe /d /s /c` spawn to avoid the warning if preferred.
- No automated test is included: CI runs on Linux, where the `win32`
  branch is never taken, and the existing fake-pi fixtures
  (`GLLA_PI_BINARY` → a `.mjs` shebang script) don't exercise it.
