### PR TITLE
fix: add stale revision rejection guidance to continuation prompt

### DIFF
--- a/extensions/goal-continuation.ts
+++ b/extensions/goal-continuation.ts
@@ -1173,6 +1173,28 @@ export function continuationPrompt(goal: Goal): string {
       `## LATEST AUDITOR ${label} (${lastAudit.at})\n\nThe auditor ${label.toLowerCase()} the last completion claim. Here is the full report:\n\n${report}`,
     );
   }
+  
+  // v0.35.x: detect stale revision rejection — auditor approved at old revision,
+  // goal contract has since advanced. The approval was refused; agent must call
+  // complete_goal again to trigger a fresh audit at current revision.
+  const currentRevision = goal.revision ?? 0;
+  const auditedRevision = lastAudit?.revision ?? 0;
+  if (
+    goal.status === "active" &&
+    !goal.pendingCompletion &&
+    lastAudit &&
+    lastAudit.approved &&
+    !lastAudit.disapproved &&
+    !lastAudit.impossible &&
+    lastAudit.regressionShieldPassed !== false &&
+    currentRevision > auditedRevision
+  ) {
+    directives.push(
+      "## STALE AUDITOR APPROVAL — REVISION MISMATCH\n\n" +
+      "The auditor APPROVED the last completion claim at revision " + auditedRevision + ", but the goal contract has since advanced to revision " + currentRevision + ". The approval was REFUSED as stale.\n\n" +
+      "**Action required:** Call `complete_goal` AGAIN with the same completion summary — this will trigger a fresh audit at the current contract revision (" + currentRevision + "). Do NOT pause or tweak; the work is done, the auditor just needs to re-verify at the new revision.",
+    );
+  }
   const dynamicDirectives = directives.length > 0 ? directives.join("\n\n") : "(no active directives)";
   // Use replacement callbacks: String.replace interprets `$&`, `$1`, `$'`,
   // and ``$``` inside replacement strings, which can corrupt perfectly valid

--- a/extensions/goal-continuation.ts
+++ b/extensions/goal-continuation.ts
@@ -1160,6 +1160,19 @@ export function continuationPrompt(goal: Goal): string {
       "## FULL-AUDIT MODE (aggressiveMode + survey objective)\n\nThis objective is a survey, not a single fix. Spawn 3+ `Explore` subagents NOW — one per subsystem, in a single message so they run in parallel — synthesize their findings, and call `propose_task_list` with the result. Do not start fixing before the task list exists.",
     );
   }
+  // v0.35.x: include the latest auditor disapproval/impossible/shield-blocked report so the agent
+  // sees the actual objections instead of a generic instruction.
+  const lastAudit = goal.auditHistory?.[goal.auditHistory.length - 1];
+  if (lastAudit && lastAudit.report) {
+    const report = lastAudit.report.trim();
+    let label = "DISAPPROVAL";
+    if (lastAudit.impossible) label = "IMPOSSIBLE";
+    else if (lastAudit.approved && lastAudit.regressionShieldPassed === false) label = "REGRESSION SHIELD BLOCKED";
+    else if (lastAudit.disapproved) label = "DISAPPROVAL";
+    directives.push(
+      `## LATEST AUDITOR ${label} (${lastAudit.at})\n\nThe auditor ${label.toLowerCase()} the last completion claim. Here is the full report:\n\n${report}`,
+    );
+  }
   const dynamicDirectives = directives.length > 0 ? directives.join("\n\n") : "(no active directives)";
   // Use replacement callbacks: String.replace interprets `$&`, `$1`, `$'`,
   // and ``$``` inside replacement strings, which can corrupt perfectly valid


### PR DESCRIPTION
When auditor approves at revision N but goal contract advances to revision N+1 during work, the approval is refused as stale (revision mismatch). The agent previously saw no guidance and would loop calling complete_goal / pausing.

Now the continuation prompt detects this state (active status, no pending completion, last audit was approved but at older revision) and instructs the agent to call complete_goal again to trigger a fresh audit at current revision.

**Detection logic:**
- Goal status is 'active' (not 'auditing')
- No pendingCompletion
- Last audit was approved (not disapproved/impossible/shield-blocked)
- Current goal.revision > audit.revision

**Guidance injected:** Clear directive to call `complete_goal` again with same summary to trigger fresh audit at current revision.