### PR TITLE
fix: pause_goal ends the turn so decision options actually reach the user [early investigation / suggestion only]

### DIFF
--- a/extensions/loops/goal-tools.ts
+++ b/extensions/loops/goal-tools.ts
@@ -1225,7 +1225,7 @@ function registerAgentTools(pi: any): void {
   pi.registerTool(defineTool({
     name: "pause_goal",
     label: "Pause goal",
-    description: "Pause the active goal with a reason and suggested action. Use when blocked on user input or unable to make progress. When the user must CHOOSE between options, pass kind=\"decision\" with the options list (recommended = 1-based index of the best one) — decision pauses render as a prominent DECISION NEEDED card. Time-gated waits (retry at a specific time) use kind=\"wait\" with resumeAt (ISO). Operational failures use kind=\"error\". VOCABULARY (v0.28.24): decision options and reasons must reference REAL commands only — /goal resume, /goal cancel, /goal tweak \"<new text>\", /list remove N, /list next, /list resume, /loop stop, /loop resume. These all act on the ACTIVE goal/item: there is NO /goal drop and NO command takes a goal id. Never show goal ids to the user — name the thing ('the active goal', 'list item \"<short name>\"'); ids are internal plumbing the user cannot act on.",
+    description: "Pause the active goal with a reason and suggested action. Use when blocked on user input or unable to make progress. Pausing ABORTS the current turn immediately — after this call, stop; never keep working. When the user must CHOOSE between options, pass kind=\"decision\" with the options list (recommended = 1-based index of the best one) — decision pauses render as a prominent DECISION NEEDED card and pop a picker for the user. Time-gated waits (retry at a specific time) use kind=\"wait\" with resumeAt (ISO). Operational failures use kind=\"error\". VOCABULARY (v0.28.24): decision options and reasons must reference REAL commands only — /goal resume, /goal cancel, /goal tweak \"<new text>\", /list remove N, /list next, /list resume, /loop stop, /loop resume. These all act on the ACTIVE goal/item: there is NO /goal drop and NO command takes a goal id. Never show goal ids to the user — name the thing ('the active goal', 'list item \"<short name>\"'); ids are internal plumbing the user cannot act on.",
     parameters: Type.Object({
       reason: Type.String({ description: "Why the work is paused" }),
       suggestedAction: Type.Optional(Type.String({ description: "What the user should do next" })),
@@ -1240,6 +1240,10 @@ function registerAgentTools(pi: any): void {
       const ctx = currentToolContext(execCtx);
       if (!ctx) return staleToolResult();
       const p = params as { reason: string; suggestedAction?: string; kind?: "decision" | "error" | "wait" | "blocked"; options?: string[]; recommended?: number; resumeAt?: string };
+      // v0.35.15: a model that passes options but forgets kind="decision"
+      // still gets the decision card — a non-empty options array IS the
+      // decision intent; silently dropping it left the user with no picker.
+      if (!p.kind && p.options && p.options.length > 0) p.kind = "decision";
       if (!state.goal) return { content: [{ type: "text", text: "No active goal." }], details: {} };
       // A late model/tool call from the previous turn must not overwrite a
       // paused or auditing lifecycle. That race made a genuine stop look
@@ -1344,12 +1348,29 @@ function registerAgentTools(pi: any): void {
           /* best-effort */
         }
       }
+      // v0.35.15: a pause ENDS the turn. Before this fix the tool result was
+      // just text — pi kept the same turn running, the model kept working
+      // past its own pause ("the agent moves on"), and the deferred decision
+      // picker lost the race: the user was never shown the options. Abort
+      // (the same mechanism /goal cancel and the zero-stream watchdog use)
+      // so the session actually stops on an idle surface where the decision
+      // picker can own the screen. The impossible-drop advance is the one
+      // exception: the queue already moved to the next item and its
+      // continuation owns this turn — aborting would kill the hand-off.
+      if (!droppedImpossible) {
+        try {
+          ctx.abort();
+          appendLedger(ctx.cwd, "pause_goal_aborted_turn", { goalId: state.goal?.id, kind: p.kind ?? "blocked" });
+        } catch (abortError) {
+          appendLedger(ctx.cwd, "pause_goal_abort_failed", { goalId: state.goal?.id, error: abortError instanceof Error ? abortError.message : String(abortError) });
+        }
+      }
       return {
         content: [{
           type: "text",
           text: droppedImpossible
             ? "The list item was auto-dropped as impossible (blocked with no resume path) — the list moved on instead of stopping."
-            : `Goal paused. ${activeGoalSurfaceCommand("resume")} to continue.`,
+            : `Goal paused. The turn ends here — do NOT continue working. ${activeGoalSurfaceCommand("resume")} to continue.`,
         }],
         details: {},
       };

--- a/tests/pause-decision-interrupt.test.ts
+++ b/tests/pause-decision-interrupt.test.ts
@@ -1,0 +1,269 @@
+// pi-goal-list-loop-audit — v0.35.15
+// tests/pause-decision-interrupt.test.ts
+//
+// Field complaint (2026-08-21): "glla agents fail to properly kick off a
+// decide event and the user is never given an option before the agent moves
+// on." Root cause was two-fold:
+//
+//   1. pause_goal only returned text — pi kept the SAME turn running after
+//      the tool result, so the model kept working past its own pause and
+//      the 600ms-deferred decision picker lost the race against continued
+//      generation (pi serializes dialogs; the user saw nothing until the
+//      turn ended, by which time the agent had moved on).
+//   2. A model that passed options but omitted kind="decision" had its
+//      options silently dropped — no card, no picker, nothing.
+//
+// Contract under test:
+//   1. kind="decision" + options → persisted pauseKind/pauseOptions AND the
+//      turn is aborted (ctx.abort) with a ledger entry.
+//   2. options WITHOUT kind → inferred as decision (lenient intent).
+//   3. Any agent-authored pause aborts the turn (blocked/error/wait too).
+//   4. The impossible-drop auto-advance path does NOT abort (the queue's
+//      continuation owns the turn).
+//   5. The decision picker wiring (maybeDecisionPopup on decision pauses)
+//      stays pinned in the source.
+
+import { test, afterEach } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+
+import { readState } from "../extensions/goal-loop-core.js";
+import activate, {
+  __testOnlyLoadState,
+  __testOnlyResetOwnerSession,
+} from "../extensions/loops/goal.js";
+import {
+  MockPi,
+  makeMockCtx,
+  tmpCwd,
+  seedState,
+  seedGoal,
+  tick,
+  type MockCtx,
+} from "./harness/mock-pi.js";
+
+const GLOBAL_SETTINGS_PATH = process.env.GLLA_GLOBAL_SETTINGS_PATH!;
+function setGlobalAutoResume(v: boolean): void {
+  fs.writeFileSync(
+    GLOBAL_SETTINGS_PATH,
+    JSON.stringify(
+      v
+        ? { autoResume: true, aggressiveMode: false }
+        : { aggressiveMode: false },
+    ),
+  );
+}
+
+const pi = new MockPi();
+activate(pi.api);
+const MAIN_SM = { name: "main-session-manager" };
+
+afterEach(() => {
+  setGlobalAutoResume(false);
+  pi.execHandler = null;
+  __testOnlyResetOwnerSession();
+});
+
+function readLedger(cwd: string): Array<{ type: string; value?: any }> {
+  const raw = fs.readFileSync(`${cwd}/.pi-glla/active.jsonl`, "utf-8");
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+/** Mock ctx that counts abort() calls — the "did the turn actually stop" probe. */
+function abortCountingCtx(cwd: string): { ctx: MockCtx; aborts: () => number } {
+  let count = 0;
+  const base = makeMockCtx(cwd, { sessionManager: MAIN_SM }) as Record<
+    string,
+    unknown
+  >;
+  const ctx = Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
+    abort: () => {
+      count++;
+    },
+  }) as unknown as MockCtx;
+  return { ctx, aborts: () => count };
+}
+
+/** Active goal restored through session_start (the owner-session gate).
+ * Returns an aborts() probe counting turn-abort calls on the SAME ctx object
+ * the tool resolves through currentToolContext(execCtx). */
+async function activeGoalFixture(
+  goalOverrides: Record<string, unknown> = {},
+): Promise<{ cwd: string; ctx: MockCtx; aborts: () => number }> {
+  setGlobalAutoResume(true); // keep the goal ACTIVE past the restore gate
+  const cwd = tmpCwd();
+  __testOnlyResetOwnerSession();
+  seedState(cwd, {
+    goal: seedGoal({ status: "active", policy: "goal", ...goalOverrides }),
+    list: [],
+    loop: null,
+  });
+  const { ctx, aborts } = abortCountingCtx(cwd);
+  await pi.fire("session_start", { reason: "reload" }, ctx);
+  await tick();
+  return { cwd, ctx, aborts };
+}
+
+function runPauseTool(
+  ctx: MockCtx,
+  params: Record<string, unknown>,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  return pi.runTool("pause_goal", params, ctx) as Promise<{
+    content: Array<{ type: string; text: string }>;
+  }>;
+}
+
+test("decision pause persists options AND aborts the turn so the picker owns an idle surface", async () => {
+  const { cwd, ctx, aborts } = await activeGoalFixture();
+
+  const res = await runPauseTool(ctx, {
+    reason: "two viable architectures — user picks",
+    kind: "decision",
+    options: [
+      "Option A (/goal resume)",
+      'Option B (/goal tweak "do B instead")',
+    ],
+    recommended: 1,
+  });
+  await tick();
+
+  const g = readState(cwd).goal as {
+    status: string;
+    pauseKind?: string;
+    pauseOptions?: string[];
+    pauseRecommended?: number;
+  };
+  assert.equal(g.status, "paused");
+  assert.equal(g.pauseKind, "decision");
+  assert.deepEqual(g.pauseOptions, [
+    "Option A (/goal resume)",
+    'Option B (/goal tweak "do B instead")',
+  ]);
+  assert.equal(g.pauseRecommended, 1);
+  // THE fix: the turn ends — the model cannot keep working past its own pause.
+  assert.equal(aborts(), 1, "pause_goal must abort the running turn");
+  assert.equal(
+    readLedger(cwd).filter((l) => l.type === "pause_goal_aborted_turn").length,
+    1,
+    "abort ledgered",
+  );
+  assert.match(res.content[0]!.text, /turn ends here/);
+});
+
+test("options without kind are inferred as decision — no silently dropped picker", async () => {
+  const { cwd, ctx, aborts } = await activeGoalFixture();
+
+  await runPauseTool(ctx, {
+    reason: "user must choose",
+    options: ["/goal resume — keep going", "/goal cancel — stop"],
+  });
+  await tick();
+
+  const g = readState(cwd).goal as {
+    pauseKind?: string;
+    pauseOptions?: string[];
+  };
+  assert.equal(
+    g.pauseKind,
+    "decision",
+    "non-empty options imply kind=decision",
+  );
+  assert.equal(g.pauseOptions?.length, 2);
+  assert.ok(aborts() >= 1, "inferred decision pauses also end the turn");
+});
+
+test("every agent-authored pause ends the turn (blocked/error/wait), not just decisions", async () => {
+  for (const kind of ["blocked", "error", "wait"] as const) {
+    const { cwd, ctx, aborts } = await activeGoalFixture();
+    try {
+      await runPauseTool(
+        ctx,
+        kind === "wait"
+          ? {
+              reason: "quota resets soon",
+              kind,
+              resumeAt: new Date(Date.now() + 60_000).toISOString(),
+            }
+          : { reason: "cannot proceed alone", kind },
+      );
+      await tick();
+      assert.equal(aborts(), 1, `kind=${kind} must abort the turn`);
+      assert.equal(
+        (readState(cwd).goal as { status: string }).status,
+        "paused",
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  }
+});
+
+test("impossible-drop auto-advance does NOT abort — the next item's continuation owns the turn", async () => {
+  setGlobalAutoResume(true);
+  const cwd = tmpCwd();
+  try {
+    __testOnlyResetOwnerSession();
+    seedState(cwd, {
+      goal: seedGoal({
+        status: "active",
+        policy: "list",
+        objective: "impossible item A",
+      }),
+      list: [{ id: "q-item-2", objective: "second list item" }],
+      loop: null,
+    });
+    const { ctx } = abortCountingCtx(cwd);
+    await pi.fire("session_start", { reason: "reload" }, ctx);
+    await tick();
+
+    const res = await runPauseTool(ctx, {
+      reason: "the API is gone and nothing else can do this",
+      kind: "blocked",
+    });
+    await tick();
+
+    // The queue advanced (existing contract, impossible-list-drop.test.ts).
+    const advanced = readState(cwd).goal as {
+      objective: string;
+      status: string;
+    };
+    assert.equal(advanced.objective, "second list item");
+    assert.equal(advanced.status, "active");
+    // …and the advance was not killed by a pause-time abort.
+    const ledger = readLedger(cwd);
+    assert.equal(
+      ledger.filter((l) => l.type === "pause_goal_aborted_turn").length,
+      0,
+      "no abort on the drop path",
+    );
+    assert.match(res.content[0]!.text, /auto-dropped as impossible/);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("source pins: decision picker wiring + abort ordering survive refactors", () => {
+  const src = fs.readFileSync("extensions/loops/goal-tools.ts", "utf-8");
+  // The picker fires for decision pauses (before the abort block).
+  assert.match(
+    src,
+    /if \(p\.kind === "decision" && p\.options && p\.options\.length > 0\) maybeDecisionPopup\(ctx\);/,
+  );
+  // Abort is inside pause_goal's execute, guarded against the drop path.
+  const exec = src.match(/name: "pause_goal",[\s\S]*?^ {4}\},$/m);
+  assert.ok(exec, "pause_goal registration found");
+  assert.match(
+    exec![0],
+    /if \(!droppedImpossible\) \{[\s\S]{0,600}?ctx\.abort\(\)/,
+    "abort guarded by !droppedImpossible",
+  );
+  assert.match(exec![0], /pause_goal_aborted_turn/, "abort ledgered");
+  // Lenient inference lives before the state guard.
+  assert.match(
+    src,
+    /if \(!p\.kind && p\.options && p\.options\.length > 0\) p\.kind = "decision";/,
+  );
+});


### PR DESCRIPTION
> ## ⚠️ Early investigation only — code is a suggestion
> This PR is **purely an early investigation** into the reported behavior. The code here is **only a suggestion**: it demonstrates one root-cause hypothesis and a minimal fix shape. It has **not** been reviewed for style, edge cases, or interaction with adjacent subsystems, and should not be merged as-is without maintainer review and testing on real agent sessions.

## Problem

Agents calling `pause_goal` — especially `kind="decision"` — never actually hand control to the user:

1. The tool only returned text. pi keeps the **same turn running** after a tool result, so the model kept working past its own pause ("the agent moves on").
2. The decision picker (`maybeDecisionPopup`) is deferred 600ms and pi serializes dialogs — it loses the race against continued generation. The user sees nothing until the turn ends.
3. A model that passed `options` but omitted `kind="decision"` had its options **silently dropped**: no card, no picker.

## Proposed fix (suggestion)

- `pause_goal` now calls `ctx.abort()` after persisting the pause — the same mechanism `/goal cancel` and the zero-stream watchdog already use — so the session stops on an idle surface where the DECISION NEEDED card and its `select()` picker own the screen. Ledgered as `pause_goal_aborted_turn`.
  - The impossible-drop auto-advance path is exempt: the queue's next-item continuation owns that turn; aborting would kill the hand-off.
- A non-empty `options` array without an explicit `kind` is inferred as `kind="decision"` instead of being silently discarded.
- Tool description teaches the model that pausing ends the turn: *"Pausing ABORTS the current turn immediately — after this call, stop; never keep working."*

## Tests

New `tests/pause-decision-interrupt.test.ts` (5 tests):

1. decision pause persists options AND aborts the turn (abort probe + ledger assert)
2. options without kind are inferred as decision
3. every agent-authored pause kind (blocked/error/wait) ends the turn
4. impossible-drop auto-advance does NOT abort (queue advance contract preserved)
5. source pins for picker wiring + abort ordering

All 5 pass against this branch; `npx tsc --noEmit` clean.

## Notes for reviewers

- An alternative shape would be a dedicated tool result convention that pi itself treats as turn-terminal, avoiding the extension-side abort entirely — worth discussing if maintainers prefer lifecycle ownership at the host layer.
- The abort fires for all agent-authored pause kinds, not just decisions, on the theory that "paused" means "stop working now"; if some pause kinds should let the model finish its sentence, the guard is a one-line change.
