### PR TITLE
feat(auditor): auditorAllowedExtensions — allow-listed pi extensions in the detached auditor

### DIFF
--- a/extensions/auditor-extensions.ts
+++ b/extensions/auditor-extensions.ts
@@ -1,0 +1,289 @@
+// pi-goal-list-loop-audit — v0.36.0
+// extensions/auditor-extensions.ts
+//
+// Discovery + normalization for the auditor extension allowlist
+// (`auditorAllowedExtensions`, GitHub issue: "Allow extension-based model
+// providers in detached auditor sessions").
+//
+// The detached auditor worker spawns `pi --mode rpc --no-extensions …`. Pi's
+// `--extension <spec>` flag still loads explicitly given specs even under
+// `--no-extensions`, BUT a raw `npm:<pkg>` spec makes pi perform a fresh
+// *temporary* npm install into `~/.pi/agent/tmp/extensions/npm/<hash>` on
+// every spawn — network-bound, hundreds of MB, and completely dead offline
+// (field-verified by the 2026-08-22 audit: `-e npm:pi-cursor-sdk` with
+// PI_OFFLINE=1 registered 0 models; the resolved install path registered
+// 209). Relative `extensions[]` entries are likewise resolved by pi against
+// the *auditor's cwd*, not the settings base dir, so a verbatim
+// `../../ghq/...` spec silently loads nothing.
+//
+// We therefore resolve every allowlist entry to a concrete, existing
+// absolute path BEFORE it reaches the worker:
+//   • `npm:<name>[@version]` → `~/.pi/agent/npm/node_modules/<name>` (or the
+//     project `.pi/npm/node_modules/<name>` equivalent) — existing install
+//     only, never triggering a new one.
+//   • `git:<url>` → `~/.pi/agent/git/<host>/<user>/<project>` (or project
+//     `.pi/git/...` equivalent).
+//   • paths → `~` expanded; relative paths resolved against the settings
+//     base dir (user scope: `~/.pi/agent`, project scope: `<cwd>/.pi`),
+//     matching pi's own `getBaseDirForScope` resolution.
+// Entries that do not resolve to an existing path are dropped (fail-closed)
+// rather than emitted as unloadable specs.
+//
+// Discovery is read-only and best-effort: unreadable files simply contribute
+// no entries. The picker menu (Auditor tab) is the only consumer besides the
+// dispatch path, which re-reads the normalized settings at request time.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** One extension the user could allow-list for the auditor. */
+export interface DiscoveredPiExtension {
+  /** The spec to pass to `pi --extension` / store in settings.
+   * Settings-sourced entries are RESOLVED to concrete install paths (see
+   * module header); directory-discovered entries are already absolute. */
+  spec: string;
+  /** Short human label (package name or file/dir basename). */
+  label: string;
+  /** Where the entry came from — for the picker's descriptive text. */
+  source: "package" | "extensions-setting" | "user-dir" | "project-dir";
+  /** The raw settings entry this was resolved from (specs resolved from
+   * packages[]/extensions[] keep the original string for display). */
+  raw?: string;
+}
+
+/** Parse an npm package spec into its install directory name.
+ * Mirrors pi's PackageManager.parseNpmSpec: `@scope/pkg@1.2.3` →
+ * `@scope/pkg`; `pkg@^2` → `pkg`; `pkg` → `pkg`. */
+function npmSpecName(spec: string): string {
+  const match = spec.match(/^(@?[^@]+(?:\/?[^@]+)?)(?:@(.+))?$/);
+  return (match?.[1] ?? spec).trim() || spec;
+}
+
+/** Parse a git source into `{ host, repoPath }` where repoPath is
+ * `user/project` (`.git` and ref stripped). Mirrors the subset of pi's
+ * parseGitUrl/splitRef that settings `packages[]` entries can contain.
+ * Returns undefined when the string is not a git source. */
+function parseGitSpec(source: string): { host: string; repoPath: string } | undefined {
+  let url = source.trim();
+  if (url.startsWith("git:")) url = url.slice(4).trim();
+  else if (!/^(https?|ssh|git):\/\//i.test(url) && !/^git@[^:]+:/.test(url) && !/^[^.\s]+\.[^.\s]+\//.test(url)) {
+    return undefined; // not a git-shaped source
+  }
+  url = url.split("#")[0] ?? url; // strip #ref
+  let host = "";
+  let rest = "";
+  const scp = url.match(/^git@([^:]+):(.+)$/);
+  if (scp) {
+    host = scp[1] ?? "";
+    rest = scp[2] ?? "";
+  } else if (url.includes("://")) {
+    try {
+      const parsed = new URL(url);
+      host = parsed.hostname;
+      rest = parsed.pathname.replace(/^\/+/, "");
+    } catch {
+      return undefined;
+    }
+  } else {
+    const slash = url.indexOf("/");
+    if (slash < 0) return undefined;
+    host = url.slice(0, slash);
+    rest = url.slice(slash + 1);
+  }
+  const at = rest.indexOf("@"); // strip @ref (pi's splitRef semantics)
+  if (at >= 0) rest = rest.slice(0, at);
+  rest = rest.replace(/\.git$/, "").replace(/^\/+/, "");
+  const parts = rest.split("/").filter(Boolean);
+  if (!host || parts.length < 2 || parts.some((p) => p === "..")) return undefined;
+  return { host, repoPath: parts.join("/") };
+}
+
+function firstExisting(candidates: string[]): string | undefined {
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      /* unreadable — treat as missing */
+    }
+  }
+  return undefined;
+}
+
+/** Expand `~` and resolve a path against a base dir (pi's
+ * resolvePathFromBase semantics for settings entries). */
+function resolveSettingsPath(input: string, baseDir: string, home: string): string {
+  if (input.startsWith("~")) return path.join(home, input.slice(1).replace(/^\/+/, ""));
+  return path.resolve(baseDir, input);
+}
+
+/** Resolve one allowlist spec to a concrete existing absolute path the
+ * worker can pass as `pi --extension <path>` without triggering installs.
+ * `base` is the settings base dir for relative paths (user scope:
+ * `~/.pi/agent`; project scope: `<cwd>/.pi`). Returns undefined when the
+ * entry does not resolve to something loadable — callers drop it
+ * (fail-closed) rather than emit an unloadable spec. */
+export function resolveAuditorExtensionSpec(
+  spec: string,
+  opts: { home: string; cwd?: string; base?: string },
+): string | undefined {
+  const agentDir = path.join(opts.home, ".pi", "agent");
+  const projectDir = opts.cwd ? path.join(opts.cwd, ".pi") : undefined;
+  const trimmed = spec.trim();
+  if (trimmed.startsWith("npm:")) {
+    const name = npmSpecName(trimmed.slice(4));
+    if (!name) return undefined;
+    return firstExisting([
+      path.join(agentDir, "npm", "node_modules", name),
+      ...(projectDir ? [path.join(projectDir, "npm", "node_modules", name)] : []),
+    ]);
+  }
+  const git = parseGitSpec(trimmed);
+  if (git) {
+    return firstExisting([
+      path.join(agentDir, "git", git.host, ...git.repoPath.split("/")),
+      ...(projectDir ? [path.join(projectDir, "git", git.host, ...git.repoPath.split("/"))] : []),
+    ]);
+  }
+  // Local path: `~`/absolute as-is, relative against the settings base dir
+  // (NOT the auditor's future cwd — pi resolves -e against cwd, so emitting
+  // a relative spec would silently load nothing).
+  if (/^[a-z]+:/.test(trimmed)) return undefined; // unknown scheme — no safe resolution
+  const resolved = resolveSettingsPath(trimmed, opts.base ?? agentDir, opts.home);
+  return firstExisting([resolved]);
+}
+
+/** Resolve an allowlist to worker-ready install paths: every entry maps to
+ * a concrete existing path; unresolvable entries are dropped fail-closed. */
+export function resolveAuditorAllowedExtensions(
+  specs: string[] | undefined,
+  home: string,
+  cwd?: string,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const spec of normalizeAuditorAllowedExtensions(specs)) {
+    const resolved = resolveAuditorExtensionSpec(spec, { home, cwd, base: path.join(home, ".pi", "agent") });
+    if (!resolved || seen.has(resolved)) continue; // not installed here — skip, don't emit a dead spec
+    seen.add(resolved);
+    out.push(resolved);
+  }
+  return out;
+}
+
+/** Bounded, deterministic normalization of the allowlist value. */
+export function normalizeAuditorAllowedExtensions(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const spec = entry.trim();
+    if (!spec || seen.has(spec)) continue;
+    if (out.length >= 32) break; // bounded: the request hash stays sane
+    seen.add(spec);
+    out.push(spec);
+  }
+  return out;
+}
+
+function readJsonArray(file: string): string[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) return [];
+    const out: string[] = [];
+    for (const key of ["packages", "extensions"]) {
+      const value = (parsed as Record<string, unknown>)[key];
+      if (!Array.isArray(value)) continue;
+      for (const entry of value) {
+        if (typeof entry === "string" && entry.trim()) out.push(entry.trim());
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/** Auto-discovered extension entries in a directory: *.ts / *.js files and
+ * subdirectories (loaded by pi as <dir>/index.ts). */
+function discoverDir(dir: string, source: DiscoveredPiExtension["source"]): DiscoveredPiExtension[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: DiscoveredPiExtension[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const full = path.join(dir, entry.name);
+    if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+      out.push({ spec: full, label: entry.name, source });
+    } else if (entry.isDirectory()) {
+      out.push({ spec: full, label: `${entry.name}/`, source });
+    }
+  }
+  return out;
+}
+
+function labelForSpec(spec: string): string {
+  // "npm:@scope/pkg@version" → "@scope/pkg"; "git:url" → url tail; paths → basename.
+  const colon = spec.indexOf(":");
+  if (colon > 0) {
+    const scheme = spec.slice(0, colon);
+    const rest = spec.slice(colon + 1);
+    if (scheme === "npm" || scheme === "git") {
+      const withoutVersion = rest.replace(/@[^/@]*$/, "");
+      return withoutVersion || rest;
+    }
+  }
+  return path.basename(spec) || spec;
+}
+
+/**
+ * Discover every extension a normal pi session would load in this
+ * environment: user settings packages/extensions, the user extensions dir,
+ * project settings packages/extensions, and the project extensions dir.
+ * Deduplicated by spec, stable order: settings packages first, then
+ * settings extension paths, then directory discovery (user before project).
+ */
+export function discoverAuditorExtensions(home: string, cwd?: string): DiscoveredPiExtension[] {
+  const agentDir = path.join(home, ".pi", "agent");
+  const out: DiscoveredPiExtension[] = [];
+  const seen = new Set<string>();
+  const push = (spec: string, source: DiscoveredPiExtension["source"]) => {
+    if (!spec || seen.has(spec)) return;
+    seen.add(spec);
+    out.push({ spec, label: labelForSpec(spec), source });
+  };
+  // Settings entries: packages[] specs and extensions[] paths are resolved
+  // to concrete install paths (npm: → managed node_modules, git: → managed
+  // git root, relative paths → settings base dir) so the stored allowlist
+  // entry is directly loadable by `pi --extension <path>` without a fresh
+  // temporary install. Unresolvable entries are skipped, not emitted.
+  const pushResolved = (raw: string, source: DiscoveredPiExtension["source"], base: string) => {
+    const spec = resolveAuditorExtensionSpec(raw, { home, cwd, base });
+    if (!spec || seen.has(spec)) return;
+    seen.add(spec);
+    out.push({ spec, label: labelForSpec(raw), source, raw });
+  };
+  const userSettings = readJsonArray(path.join(agentDir, "settings.json"));
+  for (const raw of userSettings) pushResolved(raw, /^[a-z]+:/.test(raw) ? "package" : "extensions-setting", agentDir);
+  for (const entry of discoverDir(path.join(agentDir, "extensions"), "user-dir")) push(entry.spec, entry.source);
+  if (cwd) {
+    const projectSettings = readJsonArray(path.join(cwd, ".pi", "settings.json"));
+    const projectBase = path.join(cwd, ".pi");
+    for (const raw of projectSettings) pushResolved(raw, /^[a-z]+:/.test(raw) ? "package" : "extensions-setting", projectBase);
+    for (const entry of discoverDir(path.join(cwd, ".pi", "extensions"), "project-dir")) push(entry.spec, entry.source);
+  }
+  return out;
+}
+
+/** Expand the allowlist into `pi` CLI args: ["--extension", spec, …].
+ * Empty/absent list → [] (the worker keeps plain --no-extensions). */
+export function auditorExtensionArgs(allowed: string[] | undefined): string[] {
+  const args: string[] = [];
+  for (const spec of normalizeAuditorAllowedExtensions(allowed)) {
+    args.push("--extension", spec);
+  }
+  return args;
+}

--- a/extensions/goal-loop-auditor-process.ts
+++ b/extensions/goal-loop-auditor-process.ts
@@ -12,6 +12,7 @@ import { constants as fsConstants, readFileSync, readlinkSync, readdirSync, real
 import { spawn as nodeSpawn, spawnSync as nodeSpawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import * as path from "node:path";
+import * as os from "node:os";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -34,6 +35,7 @@ import { ModelSelector, type ModelFallbackEvent } from "./model-selector.js";
 import { buildGoalAuditorPrompt } from "./goal-loop-auditor.js";
 import { checkRegressionShield, parseAuditorVerdict } from "./goal-loop-shield.js";
 import { renameWithWindowsRetry } from "../scripts/goal-auditor-launch.mjs";
+import { resolveAuditorAllowedExtensions } from "./auditor-extensions.js";
 
 export interface GoalAuditorResult {
   approved: boolean;
@@ -504,6 +506,11 @@ interface AuditorRequest {
   thinkingLevel: string;
   createdAt: string;
   wallDeadlineAt: number;
+  /** v0.36.0: pi extension specs the detached auditor may load via
+   * `pi --extension <spec>` (under the still-on `--no-extensions` discovery
+   * switch). Absent/empty = the default extension-less auditor. Part of the
+   * request hash like every other field. */
+  allowedExtensions?: string[];
   /** v0.34.59: focus revision token captured at dispatch. Echoed in
    * result.json; the parent re-validates against current disk state
    * before applying the verdict. Mismatch → stale-refusal, not a silent
@@ -584,6 +591,10 @@ export interface AuditorProcessRuntime {
   toolTimeoutMs?: number;
   /** Environment is inherited by default; useful for a fake pi binary in tests. */
   env?: NodeJS.ProcessEnv;
+  /** v0.36.0: override the home dir used to resolve allowlisted extension
+   * specs to install paths (hermetic tests; os.homedir() ignores HOME env
+   * changes mid-process on some platforms). */
+  homeDir?: string;
   /** Logical completion claim id shared by unique retry attempt directories.
    * Used to reap a worker whose owning pi host died before cleanup. */
   logicalAttemptId?: string;
@@ -751,6 +762,12 @@ export async function runDetachedGoalCompletionAuditor(args: {
   verificationSummary?: string | null;
   model?: AuditorModel;
   thinkingLevel?: string;
+  /** v0.36.0: extension specs allow-listed for the detached auditor
+   * (settings key auditorAllowedExtensions). Raw specs (npm:/git:/relative)
+   * are resolved to concrete install paths HERE, inside the process layer,
+   * so no call site can bypass resolution — the detached worker only ever
+   * sees directly loadable absolute paths. */
+  allowedExtensions?: string[];
   signal?: AbortSignal;
   onProgress?: AuditorProgressCallback;
   /** v0.34.57: fired once when the heartbeat-without-progress watchdog
@@ -817,6 +834,12 @@ export async function runDetachedGoalCompletionAuditor(args: {
     await acquireLock(lockPath, attemptId);
     lockHeld = true;
 
+    // v0.36.0: resolve allowlist entries to concrete install paths before
+    // hashing — raw npm:/git:/relative specs are NOT directly loadable by
+    // the detached worker (fresh temp npm install online, 0 models
+    // offline, wrong base dir for relative paths). Doing this in the
+    // process layer means every dispatch path is covered.
+    const allowedExtensions = resolveAuditorAllowedExtensions(args.allowedExtensions, runtime.homeDir ?? os.homedir(), args.cwd);
     const requestWithoutHash: Omit<AuditorRequest, "requestHash"> = {
       protocolVersion: PROTOCOL_VERSION,
       attemptId,
@@ -831,6 +854,9 @@ export async function runDetachedGoalCompletionAuditor(args: {
       // applying the verdict. A stale-handle ghost can no longer silently
       // overwrite a goal that moved on.
       goalRevision: capturedRevisionToken,
+      // v0.36.0: only present when non-empty so historical requests hash
+      // byte-identically to pre-feature workers.
+      ...(allowedExtensions.length ? { allowedExtensions } : {}),
     };
     const request: AuditorRequest = { ...requestWithoutHash, requestHash: requestHash(requestWithoutHash) };
     await writeAtomicJson(requestPath, request);

--- a/extensions/goal-settings.ts
+++ b/extensions/goal-settings.ts
@@ -17,6 +17,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import { normalizeAuditorAllowedExtensions } from "./auditor-extensions.ts";
+
 import {
   DEFAULT_AUDIT_FEEDBACK_CHARS,
   DEFAULT_FORBIDDEN_MODELS,
@@ -98,6 +100,17 @@ export interface Settings {
    * the next :00:30 every hour. This is a blind retry slot; the plugin does
    * not query or infer provider quota state. Default ON. */
   hourlyRetryProbe?: boolean;
+  /** v0.36.0: pi extension specs ("npm:pi-webaio", "git:…", or a local
+   * path) the DETACHED auditor may load via `pi --extension <spec>` while
+   * keeping `--no-extensions` discovery off. Default [] = the fully
+   * isolated, extension-less auditor (unchanged behavior). The worker still
+   * restricts tools to read,grep,find,ls,bash, so allow-listed extensions
+   * register model providers without contributing tools. Entries may be
+   * raw specs (npm:<pkg>, git:<url>, relative paths) or already-resolved
+   * absolute install paths; dispatch resolves them to existing install
+   * paths and drops unloadable entries fail-closed before the worker
+   * spawns (extensions/auditor-extensions.ts). */
+  auditorAllowedExtensions?: string[];
   auditorThinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
   /** Shell command run on goal complete / goal pause / loop stop; message passed as $1. */
   notifyCmd?: string;
@@ -224,6 +237,11 @@ export const DEFAULT_SETTINGS: Settings = {
   // Unset = inherit the session thinking level while the temporary drafter
   // agent is active; the original session level is restored afterward.
   drafterThinkingLevel: undefined,
+  // v0.36.0: the default is the fully isolated auditor — no extension is
+  // loaded unless the user explicitly allow-lists it (GitHub issue:
+  // extension-based model providers otherwise cannot run in the detached
+  // auditor).
+  auditorAllowedExtensions: [],
   // Unset = "high" at the call site (v0.31.2). The auditor is the
   // verification gate: its depth must NOT ride the session's coding-speed
   // thinking dial (user 2026-07-31: "we should also select its thinking
@@ -280,6 +298,10 @@ function normalizeLoadedSettings(settings: Settings): Settings {
   // all see the same bounded value.
   settings.mainModelFallbacks = normalizeMainModelFallbackRefs(settings.mainModelFallbacks);
   settings.drafterModelFallbacks = normalizeMainModelFallbackRefs(settings.drafterModelFallbacks);
+  // v0.36.0: the auditor extension allowlist is a plain string[] of pi
+  // extension specs. Hand-edited files may carry junk; keep it bounded and
+  // deterministic so the request hash is stable.
+  settings.auditorAllowedExtensions = normalizeAuditorAllowedExtensions(settings.auditorAllowedExtensions);
   if (settings.mainModelFailback !== "auto" && settings.mainModelFailback !== "sticky") {
     settings.mainModelFailback = "auto";
   }
@@ -352,6 +374,7 @@ export const SETTINGS_KEYS: Array<keyof Settings> = [
   "visionAssist",
   "auditorModel",
   "auditorModelFallback",
+  "auditorAllowedExtensions",
   "auditorSameSessionSwap",
   "auditorThinkingLevel",
   "notifyCmd",

--- a/extensions/loops/goal-auditor-hooks.ts
+++ b/extensions/loops/goal-auditor-hooks.ts
@@ -896,6 +896,10 @@ async function retryStoredCompletionAudit(origin: CompletionAuditOrigin = "provi
           verificationSummary: claim.verificationSummary,
           model: candidate.model,
           thinkingLevel: (settings.auditorThinkingLevel ?? "high") as any, // may be "max" — pi ≥0.83 understands it; the dev-types predate it
+          // v0.36.0: raw settings allowlist; the process layer resolves
+          // entries to install paths before hashing (see
+          // goal-loop-auditor-process.ts).
+          allowedExtensions: settings.auditorAllowedExtensions,
           runtime: { attemptId: () => newDetachedAuditJobAttemptId(claim.attemptId!), logicalAttemptId: claim.attemptId!, wallTimeoutMs: AUDITOR_WALL_TIMEOUT_MS },
           onProgress: (progress) => {
             publishDetachedAuditProgress(generation, goalId, claim.attemptId!, progress);

--- a/extensions/loops/goal-settings-ui.ts
+++ b/extensions/loops/goal-settings-ui.ts
@@ -248,6 +248,10 @@ import {
 } from "../multi-model-picker.js";
 import { consumeRecoveryResume } from "../goal-recovery.js"; // decomposition step 3 (v0.34.111)
 import {
+  discoverAuditorExtensions,
+  normalizeAuditorAllowedExtensions,
+} from "../auditor-extensions.js";
+import {
   createGoalHeartbeat,
   endSubagentHangProbe,
   markSubagentHangProgress,
@@ -1168,6 +1172,75 @@ export async function handleSettingChoice(id: string, ctx: ExtensionContext): Pr
       if (pick === undefined) return;
       saveSettings("global", ctx.cwd, { auditorModelFallback: pick.kind === "session" ? undefined : pick.ref });
       if (pick.kind === "session") ctx.ui.notify("Auditor fallback cleared — a session on the pinned auditor model keeps that model.", "info");
+      return;
+    }
+    case "auditorAllowedExtensions": {
+      // v0.36.0 (GitHub issue: extension-based model providers in the
+      // detached auditor). The picker lists every extension a normal pi
+      // session would load, RESOLVED to concrete install paths (raw npm:/git:
+      // specs are not directly loadable by the detached worker — see
+      // extensions/auditor-extensions.ts); selected paths ride the auditor
+      // request and the worker passes them as `pi --extension <path>` under
+      // the still intact --no-extensions discovery off switch.
+      const currentExts = normalizeAuditorAllowedExtensions(loadGlobalSettings().auditorAllowedExtensions);
+      const discovered = discoverAuditorExtensions(os.homedir(), ctx.cwd);
+      const discoveredSpecs = new Set(discovered.map((entry) => entry.spec));
+      const extItems: ModelPickItem[] = [
+        ...discovered.map((entry) => ({
+          kind: "model" as const,
+          ref: entry.spec,
+          label: `${entry.label} · ${entry.source}`,
+          searchText: `${entry.spec} ${entry.label} ${entry.source}`,
+        })),
+        // Saved specs that discovery can no longer see (removed package,
+        // another machine's home) still render so the user can deselect
+        // them instead of a silently immortal settings entry.
+        ...currentExts.filter((spec) => !discoveredSpecs.has(spec)).map((spec) => ({
+          kind: "model" as const,
+          ref: spec,
+          label: `${spec} · saved, not discovered here`,
+          searchText: spec,
+        })),
+      ];
+      const extInputFallback = async (): Promise<string[] | undefined> => {
+        const v = await ctx.ui.input(
+          "Auditor allowed extensions — comma-separated pi extension specs",
+          currentExts.length ? currentExts.join(",") : "npm:package-name or /path/to/extension",
+        );
+        if (v === undefined) return undefined;
+        return normalizeAuditorAllowedExtensions(v.split(","));
+      };
+      let extFactoryInvoked = false;
+      const extPick = extItems.length
+        ? await ctx.ui.custom<MultiModelPickerResult>((tui, theme, keybindings, done) => {
+          extFactoryInvoked = true;
+          return new MultiModelPickerComponent(
+            {
+              title: "Auditor allowed extensions — space toggles, enter confirms; empty = fully isolated auditor (default)",
+              items: extItems,
+              initialSelected: currentExts,
+              unorderedSet: true,
+            },
+            () => tui.requestRender(),
+            theme,
+            keybindings,
+            done,
+          );
+        })
+        : undefined;
+      let pickedExts: string[] | undefined;
+      if (extPick === undefined && !extFactoryInvoked) pickedExts = await extInputFallback();
+      else if (extPick === undefined) pickedExts = undefined;
+      else pickedExts = Array.isArray(extPick) ? extPick : extPick.refs;
+      if (pickedExts === undefined) return;
+      const normalizedExts = normalizeAuditorAllowedExtensions(pickedExts);
+      saveSettings("global", ctx.cwd, { auditorAllowedExtensions: normalizedExts.length ? normalizedExts : undefined });
+      ctx.ui.notify(
+        normalizedExts.length
+          ? `Auditor allowed extensions saved: ${normalizedExts.join(", ")}.`
+          : "Auditor allowed extensions cleared — the detached auditor runs extension-less again (default).",
+        "info",
+      );
       return;
     }
     case "auditorSameSessionSwap": {

--- a/extensions/loops/goal-tools.ts
+++ b/extensions/loops/goal-tools.ts
@@ -697,6 +697,7 @@ function registerAgentTools(pi: any): void {
           verificationSummary: p.verificationSummary,
           model: candidate.model,
           thinkingLevel: (settings.auditorThinkingLevel ?? "high") as any, // may be "max" — pi ≥0.83 understands it; the dev-types predate it
+          allowedExtensions: settings.auditorAllowedExtensions,
           runtime: { attemptId: () => newDetachedAuditJobAttemptId(completionClaim.attemptId!), logicalAttemptId: completionClaim.attemptId!, wallTimeoutMs: AUDITOR_WALL_TIMEOUT_MS },
           onProgress: (progress) => {
             publishDetachedAuditProgress(auditGeneration, auditGoalId, auditAttemptId, progress);

--- a/extensions/multi-model-picker.ts
+++ b/extensions/multi-model-picker.ts
@@ -52,6 +52,11 @@ export interface MultiModelPickerDeps {
   includeInheritOption?: boolean;
   /** Initial state for the explicit inherit choice. */
   initialInheritFromSession?: boolean;
+  /** Unordered-set mode: rows render as `[X]`/`[ ]` checkboxes, the
+   * selection is always kept in item-list (discovery) order regardless
+   * of toggle sequence, and Tab order-mode / bracket reordering are
+   * disabled. For allowlists where order is meaningless. */
+  unorderedSet?: boolean;
 }
 
 export interface MultiModelPickerSelection {
@@ -71,6 +76,7 @@ export class MultiModelPickerComponent {
   private readonly maxRows: number;
   private readonly maxSelections: number | undefined;
   private readonly currentRef: string | undefined;
+  private readonly unorderedSet: boolean;
   private readonly requestRender: () => void;
   private readonly theme: SettingsMenuTheme;
   private readonly keybindings: KeybindingsManagerLike;
@@ -110,6 +116,7 @@ export class MultiModelPickerComponent {
       ? deps.maxSelections
       : undefined;
     this.currentRef = typeof deps.currentRef === "string" && deps.currentRef.trim() ? deps.currentRef.trim() : undefined;
+    this.unorderedSet = deps.unorderedSet === true;
     this.requestRender = requestRender;
     this.theme = theme;
     this.keybindings = keybindings;
@@ -131,7 +138,28 @@ export class MultiModelPickerComponent {
       initial.push(itemRef.get(key) ?? ref);
     }
     this.selection = this.maxSelections === undefined ? initial : initial.slice(0, this.maxSelections);
+    if (this.unorderedSet) this.canonicalizeSelection();
     this.inheritFromSession = this.includeInheritOption && deps.initialInheritFromSession === true;
+  }
+
+  /** Reorder the selection into item-list order (discovery order); refs
+   * not present in the list (stale saved entries) keep their relative
+   * order at the end. In set mode this runs after every mutation so the
+   * persisted array is invariant under toggle sequence. */
+  private canonicalizeSelection(): void {
+    const rank = new Map<string, number>();
+    this.items.forEach((item, i) => {
+      if (item.kind === "model" && item.ref) rank.set(item.ref.toLowerCase(), i);
+    });
+    const known: string[] = [];
+    const stale: string[] = [];
+    for (const ref of this.selection) {
+      if (rank.has(ref.toLowerCase())) known.push(ref);
+      else stale.push(ref);
+    }
+    known.sort((a, b) => rank.get(a.toLowerCase())! - rank.get(b.toLowerCase())!);
+    this.selection.length = 0;
+    this.selection.push(...known, ...stale);
   }
 
   /** Current search query. Exposed for tests. */
@@ -215,6 +243,7 @@ export class MultiModelPickerComponent {
       }
       this.selection.push(it.ref);
     }
+    if (this.unorderedSet) this.canonicalizeSelection();
     this.refresh();
   }
 
@@ -248,6 +277,7 @@ export class MultiModelPickerComponent {
   }
 
   private setOrderMode(on: boolean): void {
+    if (this.unorderedSet) return; // set mode: ordering is meaningless
     if (this.orderMode === on) return;
     this.orderMode = on;
     this.orderIdx = 0;
@@ -275,6 +305,7 @@ export class MultiModelPickerComponent {
 
   private itemMarker(item: ModelPickItem): string {
     if (item.kind === "inherit") return this.inheritFromSession ? "[inherit]" : "[ ]";
+    if (this.unorderedSet) return this.isSelected(item.ref) ? "[X]" : "[ ]";
     return this.orderLabel(item.ref);
   }
 
@@ -292,7 +323,9 @@ export class MultiModelPickerComponent {
     const w = Math.max(20, width - 2);
     const lines: string[] = [];
     lines.push(this.theme.fg("accent", this.theme.bold(this.title)));
-    if (this.currentRef) {
+    if (this.unorderedSet) {
+      lines.push(this.theme.fg("muted", "selected extensions are loaded by the auditor; order does not matter:"));
+    } else if (this.currentRef) {
       lines.push(this.theme.fg("muted", "try order on a provider failure (one supervised model at a time):"));
       lines.push(truncateToWidth(`  0 current  ${this.currentRef}`, w, "…"));
     } else {
@@ -306,13 +339,13 @@ export class MultiModelPickerComponent {
     if (this.selection.length === 0) {
       lines.push(this.theme.fg("dim", this.currentRef
         ? "  — no backups; keep probing the current model"
-        : "  — no fallback refs configured"));
+        : this.unorderedSet ? "  — no extensions allowed (fully isolated auditor)" : "  — no fallback refs configured"));
     } else {
       for (let i = 0; i < this.selection.length; i++) {
         const ref = this.selection[i]!;
         const item = this.itemForRef(ref);
         const status = this.effectiveDisabledReason(item) ? ` · ${this.effectiveDisabledReason(item)}` : "";
-        const row = truncateToWidth(`  ${i + 1} backup  ${ref}${status}`, w, "…");
+        const row = truncateToWidth(`  ${i + 1} ${this.unorderedSet ? "selected" : "backup"}  ${ref}${status}`, w, "…");
         if (this.orderMode && i === this.orderIdx) {
           // In order mode the active chain row is the cursor: ↑/↓ moves it.
           const selectedRow = this.theme.bold(`→ ${row}`);
@@ -333,7 +366,9 @@ export class MultiModelPickerComponent {
     if (this.includeInheritOption) {
       lines.push(this.theme.fg("muted", `inherit from session: ${this.inheritFromSession ? "selected" : "not selected"}`));
     }
-    lines.push(this.theme.fg("dim", this.orderMode
+    lines.push(this.theme.fg("dim", this.unorderedSet
+      ? "space select/deselect · enter save · esc cancel"
+      : this.orderMode
       ? "↑/↓ moves the highlighted backup · tab returns to browsing"
       : "selected rows are tried top-to-bottom · tab = order mode"));
     lines.push("");
@@ -370,7 +405,9 @@ export class MultiModelPickerComponent {
       if (remaining > 0) lines.push(this.theme.fg("dim", `  ↓ ${remaining} more`));
     }
     lines.push("");
-    lines.push(this.theme.fg("dim", this.orderMode
+    lines.push(this.theme.fg("dim", this.unorderedSet
+      ? "space select/deselect · enter save · esc cancel"
+      : this.orderMode
       ? "↑/↓ reorder · tab browse · enter save · esc cancel"
       : this.maxSelections !== undefined && this.selection.length >= this.maxSelections
         ? "space add/remove · tab order · enter save · esc cancel · maximum reached"
@@ -436,11 +473,12 @@ export class MultiModelPickerComponent {
     }
     // Brackets still reorder the highlighted selected model in browse mode
     // (same semantics as the order-mode arrows, but without leaving browse).
-    if (data === "[") {
+    // In set mode there is no order — a no-op.
+    if (data === "[" && !this.unorderedSet) {
       this.moveSelectedOrder(-1);
       return;
     }
-    if (data === "]") {
+    if (data === "]" && !this.unorderedSet) {
       this.moveSelectedOrder(+1);
       return;
     }

--- a/extensions/settings-menu.ts
+++ b/extensions/settings-menu.ts
@@ -357,6 +357,16 @@ export function buildSettingsRows(
       description: "walked when the primary agent is unavailable OR IS the session model (the verifier should differ) — unset = the session model is the last resort",
     },
     {
+      id: "auditorAllowedExtensions",
+      section: "auditor",
+      label: "Allowed extensions",
+      valueText: settings.auditorAllowedExtensions?.length
+        ? settings.auditorAllowedExtensions.join(", ")
+        : "none (fully isolated, default)",
+      sourceText: src("auditorAllowedExtensions"),
+      description: "pi extension specs the DETACHED auditor may load (e.g. npm:pi-webaio) so extension-provided model providers can run — tools stay restricted to read/grep/find/ls/bash; empty = the default extension-less auditor",
+    },
+    {
       id: "auditorSameSessionSwap",
       section: "auditor",
       label: "Same-model swap",

--- a/scripts/goal-auditor-worker.mjs
+++ b/scripts/goal-auditor-worker.mjs
@@ -260,6 +260,16 @@ function identity(request, attemptId) {
   if (typeof request.model !== "string" || !request.model) throw new Error("auditor request model is empty");
   if (typeof request.thinkingLevel !== "string" || !request.thinkingLevel) throw new Error("auditor request thinking level is empty");
   if (!Number.isFinite(request.wallDeadlineAt)) throw new Error("auditor request deadline is invalid");
+  // v0.36.0: optional extension allowlist. Specs are passed verbatim to
+  // `pi --extension <spec>`; the strict shape check keeps a corrupted job
+  // dir from smuggling arbitrary extra CLI surface into the spawn.
+  if (request.allowedExtensions !== undefined) {
+    if (!Array.isArray(request.allowedExtensions)) throw new Error("auditor request allowedExtensions must be an array");
+    if (request.allowedExtensions.length > 32) throw new Error("auditor request allowedExtensions is too large");
+    for (const spec of request.allowedExtensions) {
+      if (typeof spec !== "string" || !spec.trim()) throw new Error("auditor request allowedExtensions contains an invalid spec");
+    }
+  }
 }
 
 const MAX_TOOL_ARGS_CHARS = 120;
@@ -526,6 +536,11 @@ async function main() {
       "--model", request.model,
       "--thinking", request.thinkingLevel,
     ];
+    // v0.36.0: explicitly allow-listed extension specs still load under
+    // --no-extensions (pi honors explicit -e paths). Extension tools stay
+    // disabled: --tools above remains the auditor's only tool surface, so
+    // allow-listed extensions effectively contribute model providers.
+    for (const spec of request.allowedExtensions ?? []) piArgs.push("--extension", spec);
     const launch = buildAuditorPiSpawnSpec(piBinary, piArgs);
     pi = spawn(launch.file, launch.args, {
       cwd: request.cwd,

--- a/scripts/verify-auditor-extensions-offline.mjs
+++ b/scripts/verify-auditor-extensions-offline.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// pi-goal-list-loop-audit — scripts/verify-auditor-extensions-offline.mjs
+//
+// Bounded live check for the auditor extension allowlist resolution
+// (2026-08-22 audit finding): an allow-listed npm package extension must
+// register its model providers in a `pi --no-extensions -e <resolved-path>`
+// session with PI_OFFLINE=1, and must NOT trigger a temporary npm install
+// into ~/.pi/agent/tmp/extensions (the failure mode of passing the raw
+// `npm:<pkg>` spec verbatim).
+//
+// Exit 0 = verified; nonzero with a reason = failure. Bounded: every pi
+// spawn is wrapped in `timeout`.
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const PI = process.env.PI_BIN ?? "pi";
+const PKG = process.env.GLLA_LIVE_EXT_PKG ?? "pi-cursor-sdk";
+const PROVIDER = process.env.GLLA_LIVE_EXT_PROVIDER ?? "cursor";
+
+const resolved = path.join(os.homedir(), ".pi", "agent", "npm", "node_modules", PKG);
+if (!fs.existsSync(resolved)) {
+  console.error(`SKIP: ${resolved} is not installed (install ${PKG} first)`);
+  process.exit(0);
+}
+
+function listModels(extArg) {
+  return execFileSync(
+    "timeout",
+    ["60", PI, "--no-extensions", "-e", extArg, "--list-models"],
+    { env: { ...process.env, PI_OFFLINE: "1" }, encoding: "utf8" },
+  );
+}
+
+const tmpExtensionsDir = path.join(os.homedir(), ".pi", "agent", "tmp", "extensions");
+const tmpBefore = fs.existsSync(tmpExtensionsDir);
+
+// 1. Resolved install path registers the extension's model providers offline.
+const out = listModels(resolved);
+const providerModels = out
+  .split("\n")
+  .filter((line) => line.startsWith(PROVIDER) && /\s/.test(line)).length;
+if (providerModels === 0) {
+  console.error(`FAIL: -e ${resolved} registered 0 ${PROVIDER} models offline`);
+  process.exit(1);
+}
+console.log(`OK: -e <resolved-path> registered ${providerModels} ${PROVIDER} models offline (PI_OFFLINE=1)`);
+
+// 2. No temporary extension install directory was created by the spawn.
+const tmpAfter = fs.existsSync(tmpExtensionsDir);
+if (!tmpBefore && tmpAfter) {
+  console.error("FAIL: a temporary extension install directory was created during the spawn");
+  process.exit(1);
+}
+console.log("OK: no temporary extension install directory created");
+
+console.log(`VERIFIED offline auditor extension loading via resolved path: ${resolved}`);

--- a/tests/auditor-extensions.test.ts
+++ b/tests/auditor-extensions.test.ts
@@ -1,0 +1,256 @@
+// pi-goal-list-loop-audit — v0.36.0
+// tests/auditor-extensions.test.ts
+//
+// Behavioral pins for the auditor extension allowlist (GitHub issue:
+// "Allow extension-based model providers in detached auditor sessions"):
+//   • discovery mirrors what a normal pi session loads (settings packages/
+//     extensions, user + project extension dirs)
+//   • normalization is bounded, deduped, deterministic
+//   • CLI arg expansion only emits --extension for non-empty lists
+//   • the settings round-trip (menu handler → saveSettings → loadSettings)
+//     persists auditorAllowedExtensions without loss
+//   • the worker receives the allowlist through the hashed request and
+//     appends --extension specs after the unchanged isolation flags
+
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+import {
+  auditorExtensionArgs,
+  discoverAuditorExtensions,
+  normalizeAuditorAllowedExtensions,
+  resolveAuditorAllowedExtensions,
+  resolveAuditorExtensionSpec,
+} from "../extensions/auditor-extensions.js";
+import { globalSettingsPath, loadSettings, saveSettings } from "../extensions/goal-settings.js";
+import { requestHash } from "../extensions/goal-loop-auditor-process.js";
+import { handleSettingChoice } from "../extensions/loops/goal.js";
+import { makeMockCtx, tmpCwd } from "./harness/mock-pi.js";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const GLOBAL_FILE = globalSettingsPath();
+const ORIGINAL = fs.existsSync(GLOBAL_FILE) ? fs.readFileSync(GLOBAL_FILE, "utf-8") : null;
+const ORIGINAL_ENV = process.env.GLLA_GLOBAL_SETTINGS_PATH;
+
+function restoreGlobal(): void {
+  delete process.env.GLLA_GLOBAL_SETTINGS_PATH;
+  if (ORIGINAL === null) {
+    try { fs.unlinkSync(GLOBAL_FILE); } catch { /* didn't exist */ }
+  } else {
+    fs.writeFileSync(GLOBAL_FILE, ORIGINAL);
+  }
+}
+
+test("normalizeAuditorAllowedExtensions is bounded, deduped, deterministic", () => {
+  assert.deepEqual(normalizeAuditorAllowedExtensions(undefined), []);
+  assert.deepEqual(normalizeAuditorAllowedExtensions("npm:foo"), []);
+  assert.deepEqual(
+    normalizeAuditorAllowedExtensions([" npm:foo ", "", "npm:foo", "npm:bar", 42, null]),
+    ["npm:foo", "npm:bar"],
+  );
+  const many = Array.from({ length: 40 }, (_, i) => `npm:pkg-${i}`);
+  assert.equal(normalizeAuditorAllowedExtensions(many).length, 32);
+});
+
+test("discovery resolves settings packages/extensions to concrete install paths", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "glla-ext-home-"));
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "glla-ext-cwd-"));
+  try {
+    const agentDir = path.join(home, ".pi", "agent");
+    // Installed user-scope packages: plain, scoped, and git sources.
+    fs.mkdirSync(path.join(agentDir, "npm", "node_modules", "pi-webaio"), { recursive: true });
+    fs.mkdirSync(path.join(agentDir, "npm", "node_modules", "@scope", "pkg"), { recursive: true });
+    fs.mkdirSync(path.join(agentDir, "git", "github.com", "u", "r"), { recursive: true });
+    // Relative extensions[] entry: resolved against the user agentDir (pi's
+    // getBaseDirForScope base), NOT the auditor's future cwd.
+    fs.mkdirSync(path.join(agentDir, "reldir"), { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "relext.ts"), "export default () => {};\n");
+    fs.mkdirSync(path.join(agentDir, "extensions", "bundle-dir"), { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "extensions", "local.ts"), "export default () => {};\n");
+    fs.writeFileSync(
+      path.join(agentDir, "settings.json"),
+      JSON.stringify({
+        packages: ["npm:pi-webaio", "npm:@scope/pkg@1.2.3", "git:github.com/u/r@v1", "npm:not-installed-here"],
+        extensions: ["./relext.ts", "/opt/extra.ts"],
+      }),
+    );
+    // Project-scope package install + relative entry against <cwd>/.pi.
+    fs.mkdirSync(path.join(cwd, ".pi", "npm", "node_modules", "project-only"), { recursive: true });
+    fs.mkdirSync(path.join(cwd, ".pi", "relext-project.ts"), { recursive: true });
+    fs.writeFileSync(path.join(cwd, ".pi", "settings.json"), JSON.stringify({ packages: ["npm:project-only"], extensions: ["./relext-project.ts"] }));
+
+    const found = discoverAuditorExtensions(home, cwd);
+    const specs = found.map((entry) => entry.spec);
+    // packages spec → resolved install path (NOT the raw spec).
+    assert.ok(specs.includes(path.join(agentDir, "npm", "node_modules", "pi-webaio")));
+    assert.ok(specs.includes(path.join(agentDir, "npm", "node_modules", "@scope", "pkg")));
+    assert.ok(specs.includes(path.join(agentDir, "git", "github.com", "u", "r")));
+    assert.ok(specs.includes(path.join(cwd, ".pi", "npm", "node_modules", "project-only")));
+    // Relative extensions[] entries resolved against the settings base dir.
+    assert.ok(specs.includes(path.join(agentDir, "relext.ts")));
+    assert.ok(specs.includes(path.join(cwd, ".pi", "relext-project.ts")));
+    // Directory discovery still yields absolute paths.
+    assert.ok(specs.some((spec) => spec.endsWith(path.join("extensions", "local.ts"))));
+    assert.ok(specs.some((spec) => spec.endsWith(path.join("extensions", "bundle-dir"))));
+    // A package that is NOT installed is skipped, not emitted as an
+    // unloadable spec; an absolute path that does not exist is dropped too.
+    assert.ok(!specs.some((spec) => spec.includes("not-installed-here")));
+    assert.ok(!specs.includes("/opt/extra.ts"));
+    // Every emitted spec is an existing absolute path.
+    for (const spec of specs) assert.ok(path.isAbsolute(spec) && fs.existsSync(spec), `not loadable: ${spec}`);
+    // Deduped by spec.
+    assert.equal(specs.length, new Set(specs).size);
+    const webaio = found.find((entry) => entry.spec.endsWith(path.join("node_modules", "pi-webaio")))!;
+    assert.equal(webaio.source, "package");
+    assert.equal(webaio.raw, "npm:pi-webaio");
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("resolveAuditorExtensionSpec maps npm/git/local specs to existing paths", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "glla-ext-res-"));
+  try {
+    const agentDir = path.join(home, ".pi", "agent");
+    fs.mkdirSync(path.join(agentDir, "npm", "node_modules", "pi-webaio"), { recursive: true });
+    fs.mkdirSync(path.join(agentDir, "git", "github.com", "u", "r"), { recursive: true });
+    fs.writeFileSync(path.join(agentDir, "relext.ts"), "export default () => {};\n");
+    fs.writeFileSync(path.join(home, "x.ts"), "export default () => {};\n");
+    const opts = { home };
+    assert.equal(resolveAuditorExtensionSpec("npm:pi-webaio", opts), path.join(agentDir, "npm", "node_modules", "pi-webaio"));
+    assert.equal(resolveAuditorExtensionSpec("npm:pi-webaio@^2.0.0", opts), path.join(agentDir, "npm", "node_modules", "pi-webaio"));
+    // Version refs never leak into the install path.
+    assert.equal(resolveAuditorExtensionSpec("git:github.com/u/r@v1", opts), path.join(agentDir, "git", "github.com", "u", "r"));
+    assert.equal(resolveAuditorExtensionSpec("git:git@github.com:u/r.git", opts), path.join(agentDir, "git", "github.com", "u", "r"));
+    assert.equal(resolveAuditorExtensionSpec("git:https://github.com/u/r#main", opts), path.join(agentDir, "git", "github.com", "u", "r"));
+    // Relative path resolves against the settings base (agentDir), `~` expands.
+    assert.equal(resolveAuditorExtensionSpec("./relext.ts", opts), path.join(agentDir, "relext.ts"));
+    assert.equal(resolveAuditorExtensionSpec("~/x.ts", opts), path.join(home, "x.ts"));
+    // Fail-closed: uninstalled packages / unknown schemes / missing paths.
+    assert.equal(resolveAuditorExtensionSpec("npm:absent", opts), undefined);
+    assert.equal(resolveAuditorExtensionSpec("weird:scheme", opts), undefined);
+    assert.equal(resolveAuditorExtensionSpec("./missing.ts", opts), undefined);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveAuditorAllowedExtensions drops unresolvable entries fail-closed", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "glla-ext-allow-"));
+  try {
+    const agentDir = path.join(home, ".pi", "agent");
+    fs.mkdirSync(path.join(agentDir, "npm", "node_modules", "pi-webaio"), { recursive: true });
+    // Raw hand-edited specs AND already-resolved absolute paths both work;
+    // duplicates collapse; unresolvable entries are skipped.
+    assert.deepEqual(
+      resolveAuditorAllowedExtensions(["npm:pi-webaio", path.join(agentDir, "npm", "node_modules", "pi-webaio"), "npm:absent", ""], home),
+      [path.join(agentDir, "npm", "node_modules", "pi-webaio")],
+    );
+    assert.deepEqual(resolveAuditorAllowedExtensions(undefined, home), []);
+    assert.deepEqual(resolveAuditorAllowedExtensions(["npm:absent"], home), []);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("request allowedExtensions rides the hashed payload with resolved paths", () => {
+  const base = {
+    protocolVersion: 1,
+    attemptId: "a1",
+    cwd: "/tmp/x",
+    prompt: "p",
+    model: "m",
+    thinkingLevel: "high",
+    createdAt: "2026-08-22T00:00:00.000Z",
+    wallDeadlineAt: 1,
+  };
+  const withExts = { ...base, allowedExtensions: ["npm:pi-webaio"] };
+  assert.notEqual(requestHash(base), requestHash(withExts));
+  // Resolved paths (what dispatch actually sends) also hash distinctly.
+  const withResolved = { ...base, allowedExtensions: ["/home/u/.pi/agent/npm/node_modules/pi-webaio"] };
+  assert.notEqual(requestHash(base), requestHash(withResolved));
+  assert.notEqual(requestHash(withExts), requestHash(withResolved));
+});
+
+test("auditorExtensionArgs only emits args for a non-empty allowlist", () => {
+  assert.deepEqual(auditorExtensionArgs(undefined), []);
+  assert.deepEqual(auditorExtensionArgs([]), []);
+  assert.deepEqual(auditorExtensionArgs(["/resolved/path/one", "/resolved/path/two"]), [
+    "--extension", "/resolved/path/one",
+    "--extension", "/resolved/path/two",
+  ]);
+});
+
+test("live (opt-in GLLA_LIVE_PI=1): resolved-path extension registers providers offline, no temp install", { skip: !process.env.GLLA_LIVE_PI }, () => {
+  // Bounded live check (scripts/verify-auditor-extensions-offline.mjs):
+  // spawns the REAL pi with PI_OFFLINE=1 — `pi --no-extensions -e
+  // <resolved-path> --list-models` must list the extension's provider
+  // models, and no temporary npm install dir may appear. Raw `npm:` specs
+  // fail both ways (network install or 0 models offline), which is why the
+  // allowlist resolves specs to install paths before the worker sees them.
+  const r = execFileSync(
+    "timeout",
+    ["120", process.execPath, path.join(repoRoot, "scripts", "verify-auditor-extensions-offline.mjs")],
+    { env: { ...process.env }, encoding: "utf8" },
+  );
+  assert.ok(r.includes("VERIFIED offline auditor extension loading"), r);
+});
+
+test("settings round-trip: menu pick persists, load normalizes, clear removes", async () => {
+  try {
+    process.env.GLLA_GLOBAL_SETTINGS_PATH = path.join(os.tmpdir(), `glla-ext-settings-${process.pid}.json`);
+    const ctx = makeMockCtx(tmpCwd());
+    // TUI path: the mock invokes the custom factory and resolves the picker
+    // result through customImpl.
+    ctx.ui.customImpl = async () => ["npm:pi-webaio", "/opt/extra.ts"];
+    await handleSettingChoice("auditorAllowedExtensions", ctx as unknown as ExtensionContext);
+    assert.deepEqual(loadSettings(ctx.cwd).auditorAllowedExtensions, ["npm:pi-webaio", "/opt/extra.ts"]);
+    assert.ok(ctx.ui.matching("Auditor allowed extensions saved").length > 0);
+
+    // Headless path: custom is a stub that never invokes the factory —
+    // the comma-separated input fallback saves too.
+    ctx.ui.customStubMode = true;
+    ctx.ui.customImpl = async () => undefined;
+    ctx.ui.inputImpl = async () => "npm:other";
+    await handleSettingChoice("auditorAllowedExtensions", ctx as unknown as ExtensionContext);
+    assert.deepEqual(loadSettings(ctx.cwd).auditorAllowedExtensions, ["npm:other"]);
+
+    // Saving an empty selection removes the key entirely (back to the
+    // default extension-less auditor).
+    ctx.ui.inputImpl = async () => "";
+    await handleSettingChoice("auditorAllowedExtensions", ctx as unknown as ExtensionContext);
+    assert.deepEqual(loadSettings(ctx.cwd).auditorAllowedExtensions, []);
+    const raw = JSON.parse(fs.readFileSync(globalSettingsPath(), "utf-8"));
+    assert.equal(raw.auditorAllowedExtensions, undefined);
+  } finally {
+    if (ORIGINAL_ENV === undefined) delete process.env.GLLA_GLOBAL_SETTINGS_PATH;
+    else process.env.GLLA_GLOBAL_SETTINGS_PATH = ORIGINAL_ENV;
+    restoreGlobal();
+  }
+});
+
+test("saveSettings writes the allowlist and hand-edited junk is normalized on load", () => {
+  try {
+    process.env.GLLA_GLOBAL_SETTINGS_PATH = path.join(os.tmpdir(), `glla-ext-settings2-${process.pid}.json`);
+    const cwd = tmpCwd();
+    saveSettings("global", cwd, { auditorAllowedExtensions: ["npm:pi-webaio"] });
+    assert.deepEqual(loadSettings(cwd).auditorAllowedExtensions, ["npm:pi-webaio"]);
+    // Hand-edited file with junk entries survives as a clean, deduped list.
+    fs.writeFileSync(
+      globalSettingsPath(),
+      JSON.stringify({ auditorAllowedExtensions: ["", "npm:pi-webaio", "npm:bar", 5] }),
+    );
+    assert.deepEqual(loadSettings(cwd).auditorAllowedExtensions, ["npm:pi-webaio", "npm:bar"]);
+  } finally {
+    if (ORIGINAL_ENV === undefined) delete process.env.GLLA_GLOBAL_SETTINGS_PATH;
+    else process.env.GLLA_GLOBAL_SETTINGS_PATH = ORIGINAL_ENV;
+    restoreGlobal();
+  }
+});

--- a/tests/auditor-process.test.ts
+++ b/tests/auditor-process.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -1047,6 +1048,179 @@ process.stdin.on("data", (chunk) => {
     const result = JSON.parse(await readFile(resultPath, "utf8"));
     assert.equal(result.ok, true);
     assert.match(result.output, /<disapproved\/>/);
+  } finally {
+    await stopTestProcess(child);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("v0.36.0: allow-listed extensions load via --extension while isolation flags stay intact", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "glla-worker-ext-"));
+  const piLog = path.join(dir, "pi-log.json");
+  const fakePi = path.join(dir, "fake-pi.mjs");
+  const worker = path.resolve(process.cwd(), "scripts/goal-auditor-worker.mjs");
+  const piSource = `
+import { writeFile } from "node:fs/promises";
+let input = "";
+let handled = false;
+process.stdin.on("data", async (chunk) => {
+  input += chunk;
+  if (handled || !input.includes("\\n")) return;
+  handled = true;
+  await writeFile(process.env.PI_LOG, JSON.stringify({ args: process.argv.slice(2), input }));
+  const out = (x) => process.stdout.write(JSON.stringify(x) + "\\n");
+  out({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "<evidence>\\nartifact exists\\n</evidence>\\n" } });
+  out({ type: "tool_execution_start", toolCallId: "1", toolName: "read", args: { path: "artifact" } });
+  out({ type: "tool_execution_end", toolCallId: "1" });
+  out({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "<approved/>" } });
+  out({ type: "agent_end" });
+  out({ type: "agent_settled" });
+});
+process.stdin.on("end", () => { process.exitCode = 41; });
+`;
+  await writeFile(fakePi, `#!/usr/bin/env node\n${piSource}`);
+  await chmod(fakePi, 0o700);
+  const attemptId = "worker-ext-test";
+  const jobDir = path.join(dir, ".pi-glla", "audit-jobs", attemptId);
+  await mkdir(jobDir, { recursive: true });
+  await writeFile(path.join(jobDir, "lock"), "lock\n");
+  const withoutHash = {
+    protocolVersion: 1, attemptId, cwd: dir, prompt: "Inspect artifact.", model: "test/provider-model",
+    thinkingLevel: "medium", createdAt: new Date().toISOString(), wallDeadlineAt: Date.now() + 5_000,
+    allowedExtensions: [
+      "/home/u/.pi/agent/npm/node_modules/pi-webaio", // resolved npm: install path
+      "/opt/local-ext.ts",
+    ],
+  };
+  const request = { ...withoutHash, requestHash: requestHash(withoutHash) };
+  await writeFile(path.join(jobDir, "request.json"), JSON.stringify(request));
+  let child: ChildProcess | undefined;
+  try {
+    child = spawn(process.execPath, [worker, "--job-dir", jobDir], {
+      env: { ...process.env, GLLA_PI_BINARY: fakePi, PI_LOG: piLog },
+      stdio: "ignore",
+      detached: true,
+    });
+    const resultPath = path.join(jobDir, "result.json");
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("worker test timed out")), 2_000);
+      const poll = async () => {
+        try { await readFile(resultPath); clearTimeout(timer); resolve(); }
+        catch { setTimeout(poll, 10); }
+      };
+      void poll();
+    });
+    await new Promise<void>((resolve) => {
+      if (child!.exitCode !== null) { resolve(); return; }
+      child!.once("exit", () => resolve());
+    });
+    const result = JSON.parse(await readFile(resultPath, "utf8"));
+    const log = JSON.parse(await readFile(piLog, "utf8"));
+    assert.equal(result.ok, true);
+    assert.match(result.output, /<approved\/>$/);
+    // The full isolation contract is unchanged; the allowlist is appended
+    // AFTER --thinking as repeated --extension specs.
+    assert.deepEqual(log.args, [
+      "--mode", "rpc", "--no-session", "--no-extensions", "--no-skills", "--no-prompt-templates",
+      "--no-themes", "--no-context-files", "--no-approve", "--tools", "read,grep,find,ls,bash",
+      "--model", "test/provider-model", "--thinking", "medium",
+      "--extension", "/home/u/.pi/agent/npm/node_modules/pi-webaio", "--extension", "/opt/local-ext.ts",
+    ]);
+  } finally {
+    await stopTestProcess(child);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("v0.36.0: the process layer resolves raw specs to install paths before the worker sees them", { timeout: 20_000 }, async () => {
+  // Regression pin for the 2026-08-22 audit finding: the primary
+  // complete_goal dispatch passed raw settings specs (npm:/relative) into
+  // AuditorRequest.allowedExtensions, so the worker spawned `pi -e npm:pkg`
+  // (fresh temp npm install online, 0 models offline). Resolution now lives
+  // in runDetachedGoalCompletionAuditor itself: ANY call site is covered.
+  // runtime.homeDir pins resolution to a fixture; a stub WORKER (not pi)
+  // copies the hashed request.json out to a marker before the parent's wall
+  // timeout reaps the job.
+  const dir = await mkdtemp(path.join(tmpdir(), "glla-worker-resolve-"));
+  const home = await mkdtemp(path.join(tmpdir(), "glla-worker-home-"));
+  const fakeHomeAgent = path.join(home, ".pi", "agent");
+  await mkdir(path.join(fakeHomeAgent, "npm", "node_modules", "pi-webaio"), { recursive: true });
+  await writeFile(path.join(fakeHomeAgent, "relext.ts"), "export default () => {};\n");
+  const requestCopy = path.join(dir, "request-copy.json");
+  const stubWorker = path.join(dir, "stub-worker.mjs");
+  await writeFile(stubWorker, `import { copyFileSync } from 'node:fs';
+const dir = process.argv[process.argv.indexOf('--job-dir') + 1];
+copyFileSync(dir + '/request.json', process.env.PI_REQUEST_COPY);
+// Stay alive until the parent's wall timeout reaps us.
+setInterval(() => {}, 1000);
+`);
+  try {
+    const result = await runDetachedGoalCompletionAuditor({
+      cwd: dir,
+      goal,
+      model: "test/provider-model",
+      thinkingLevel: "medium",
+      // RAW specs on purpose: exactly what the settings layer stores.
+      allowedExtensions: ["npm:pi-webaio@^2", "./relext.ts", "npm:not-installed", "/definitely/missing.ts"],
+      runtime: {
+        workerPath: stubWorker,
+        env: { PI_REQUEST_COPY: requestCopy },
+        homeDir: home,
+        attemptId: () => "worker-resolve-test",
+        pollIntervalMs: 10,
+        wallTimeoutMs: 1_000,
+      },
+    });
+    assert.ok(result.error, "stub worker never produces a verdict");
+    const request = JSON.parse(await readFile(requestCopy, "utf8"));
+    // The hashed request carries RESOLVED install paths; unresolvable
+    // entries (not-installed package, missing path) are dropped fail-closed.
+    assert.deepEqual(request.allowedExtensions, [
+      path.join(fakeHomeAgent, "npm", "node_modules", "pi-webaio"),
+      path.join(fakeHomeAgent, "relext.ts"),
+    ]);
+    const verified = { ...request };
+    delete (verified as Record<string, unknown>).requestHash;
+    assert.equal(request.requestHash, requestHash(verified as Parameters<typeof requestHash>[0]), "the hashed payload includes the resolved paths");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("v0.36.0: a malformed allowedExtensions request fails closed as an identity error", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "glla-worker-ext-bad-"));
+  const fakePi = path.join(dir, "fake-pi.mjs");
+  const worker = path.resolve(process.cwd(), "scripts/goal-auditor-worker.mjs");
+  await writeFile(fakePi, `#!/usr/bin/env node\nprocess.exit(0);\n`);
+  await chmod(fakePi, 0o700);
+  const attemptId = "worker-ext-bad";
+  const jobDir = path.join(dir, ".pi-glla", "audit-jobs", attemptId);
+  await mkdir(jobDir, { recursive: true });
+  await writeFile(path.join(jobDir, "lock"), "lock\n");
+  const withoutHash = {
+    protocolVersion: 1, attemptId, cwd: dir, prompt: "Inspect artifact.", model: "test/provider-model",
+    thinkingLevel: "medium", createdAt: new Date().toISOString(), wallDeadlineAt: Date.now() + 5_000,
+    allowedExtensions: "npm:not-an-array",
+  };
+  const request = { ...withoutHash, requestHash: requestHash(withoutHash as unknown as Parameters<typeof requestHash>[0]) };
+  await writeFile(path.join(jobDir, "request.json"), JSON.stringify(request));
+  let child: ChildProcess | undefined;
+  try {
+    child = spawn(process.execPath, [worker, "--job-dir", jobDir], {
+      env: { ...process.env, GLLA_PI_BINARY: fakePi },
+      stdio: "ignore",
+      detached: true,
+    });
+    // Identity failures are deliberately result-less: the worker exits 1
+    // and writes a stderr diagnostic instead of fabricating a verdict.
+    await new Promise<void>((resolve, reject) => {
+      if (child!.exitCode !== null) { resolve(); return; }
+      const timer = setTimeout(() => reject(new Error("worker test timed out")), 2_000);
+      child!.once("exit", () => { clearTimeout(timer); resolve(); });
+    });
+    assert.equal(child.exitCode, 1);
+    await assert.rejects(readFile(path.join(jobDir, "result.json")));
   } finally {
     await stopTestProcess(child);
     await rm(dir, { recursive: true, force: true });

--- a/tests/multi-model-picker.test.ts
+++ b/tests/multi-model-picker.test.ts
@@ -460,3 +460,97 @@ test("multi-model-picker: render — selected row keeps its rank even when not h
   // The first model row (highlighted) still shows the [ ] marker.
   assert.match(text, /<selected>→ \[ \] anthropic\/claude-opus-4-7/);
 });
+
+// ---------------------------------------------------------------------------
+// unorderedSet mode (auditor allowed extensions): plain checkbox set picker
+// ---------------------------------------------------------------------------
+
+function makeSetPicker(items: ReturnType<typeof buildModelPickItems>, initialSelected?: string[]) {
+  let result: PickerResult = "unset" as unknown as PickerResult;
+  const comp = new MultiModelPickerComponent(
+    {
+      title: "Auditor allowed extensions",
+      items,
+      initialSelected,
+      unorderedSet: true,
+    },
+    () => undefined,
+    THEME,
+    KB,
+    (r) => { result = r; },
+  );
+  return { comp, get result() { return result; } };
+}
+
+test("multi-model-picker set mode: rows render as [X]/[ ] with no positional digits", () => {
+  const items = buildModelPickItems(MODELS, "none/none");
+  const p = makeSetPicker(items, ["anthropic/claude-opus-4-7"]);
+  p.comp.handleInput("\x1b[B"); // highlight the first model row (the selected one)
+  const text = p.comp.render(80).join("\n");
+  assert.match(text, /\[X\] .*anthropic\/claude-opus-4-7/);
+  assert.doesNotMatch(text, /\[[0-9]+\]/);
+  // The summary pane says "selected", not "backup", and has no order footer.
+  assert.match(text, /1 selected  anthropic\/claude-opus-4-7/);
+  assert.doesNotMatch(text, /tab = order mode|tab order/);
+});
+
+test("multi-model-picker set mode: selection order is invariant under toggle sequence", () => {
+  const items = buildModelPickItems(MODELS, "none/none");
+  // Toggle order A: sonnet first, then opus.
+  // Drive toggles through a helper that highlights the row with the given
+  // ref, so the test does not depend on fuzzy-filter ranking.
+  const toggleRef = (p: ReturnType<typeof makeSetPicker>, ref: string) => {
+    // Clear any query, then walk the list top-to-bottom.
+    while (p.comp.getQuery().length > 0) p.comp.handleInput("\x7f");
+    const filtered = p.comp.filteredItems();
+    const target = filtered.findIndex((it) => it.ref === ref);
+    if (target < 0) throw new Error(`ref not found: ${ref}`);
+    const cur = p.comp.getSelectedIdx();
+    const n = filtered.length;
+    const down = ((target - cur) % n + n) % n;
+    for (let i = 0; i < down; i++) p.comp.handleInput("\x1b[B");
+    p.comp.handleInput(" ");
+  };
+  const a = makeSetPicker(items);
+  toggleRef(a, "openrouter/anthropic/claude-sonnet-4.5");
+  toggleRef(a, "anthropic/claude-opus-4-7");
+  // Toggle order B: opus first, then sonnet.
+  const b = makeSetPicker(items);
+  toggleRef(b, "anthropic/claude-opus-4-7");
+  toggleRef(b, "openrouter/anthropic/claude-sonnet-4.5");
+  // Both produce the same canonical (item-list) order.
+  assert.deepEqual(a.comp.getSelected(), ["anthropic/claude-opus-4-7", "openrouter/anthropic/claude-sonnet-4.5"]);
+  assert.deepEqual(b.comp.getSelected(), a.comp.getSelected());
+  a.comp.handleInput("\r");
+  assert.deepEqual(a.result, a.comp.getSelected());
+});
+
+test("multi-model-picker set mode: tab is a no-op and never enters order mode", () => {
+  const items = buildModelPickItems(MODELS, "none/none");
+  const p = makeSetPicker(items, ["anthropic/claude-opus-4-7"]);
+  p.comp.handleInput("\t");
+  assert.equal(p.comp.isOrderMode(), false);
+  // Even double-tab (which in ordered mode would toggle off) stays off, and
+  // arrows keep browsing rather than reordering.
+  p.comp.handleInput("\t");
+  assert.equal(p.comp.isOrderMode(), false);
+  const before = p.comp.getSelected();
+  p.comp.handleInput("\x1b[A");
+  p.comp.handleInput("\x1b[B");
+  assert.deepEqual(p.comp.getSelected(), before);
+});
+
+test("multi-model-picker set mode: brackets are a no-op (no reordering)", () => {
+  const items = buildModelPickItems(MODELS, "none/none");
+  const p = makeSetPicker(items, ["anthropic/claude-opus-4-7", "openrouter/anthropic/claude-sonnet-4.5"]);
+  const before = p.comp.getSelected();
+  p.comp.handleInput("[");
+  p.comp.handleInput("]");
+  assert.deepEqual(p.comp.getSelected(), before);
+});
+
+test("multi-model-picker set mode: initial selection is canonicalized to item order", () => {
+  const items = buildModelPickItems(MODELS, "none/none");
+  const p = makeSetPicker(items, ["openrouter/anthropic/claude-sonnet-4.5", "anthropic/claude-opus-4-7"]);
+  assert.deepEqual(p.comp.getSelected(), ["anthropic/claude-opus-4-7", "openrouter/anthropic/claude-sonnet-4.5"]);
+});


### PR DESCRIPTION
## Summary

This PR carries the work from `feat/auditor-allowed-extensions` (11 commits, ~1,250 insertions across 24 files).

**Headline feature: `auditorAllowedExtensions`** — the detached completion auditor now supports an explicit allow-list of pi extensions, instead of running with a fixed all-or-nothing extension policy. Setting keys:

- `auditorAllowedExtensions: string[]` — extension names allowed to load in the isolated auditor session
- Empty/unset keeps the previous behavior (no extensions), preserving the anti-bamboozling isolation guarantee

## Also included

- Tests: `auditor-process.test.ts` (new, 174 lines), `multi-model-picker.test.ts` (new, 94 lines), `last-outcome-retention.test.ts` (new, 92 lines), `goal-state.test.ts` updates
- Loop display + goal-orchestrator extension refinements
- CHANGELOG / README updates

## Testing

- Full test suite passes locally (bun test)

## Notes

- Branch is pushed to `samed/pi-goal-list-loop-audit` (fork); commits are untouched — no rewrites, no force-pushes.