### PR TITLE
fix(settings): stop allowed-extensions paths from overflowing the TUI

### DIFF
--- a/extensions/loops/goal-settings-ui.ts
+++ b/extensions/loops/goal-settings-ui.ts
@@ -1237,7 +1237,7 @@ export async function handleSettingChoice(id: string, ctx: ExtensionContext): Pr
       saveSettings("global", ctx.cwd, { auditorAllowedExtensions: normalizedExts.length ? normalizedExts : undefined });
       ctx.ui.notify(
         normalizedExts.length
-          ? `Auditor allowed extensions saved: ${normalizedExts.join(", ")}.`
+          ? `Auditor allowed extensions saved: ${normalizedExts.length} enabled.`
           : "Auditor allowed extensions cleared — the detached auditor runs extension-less again (default).",
         "info",
       );

--- a/extensions/settings-menu.ts
+++ b/extensions/settings-menu.ts
@@ -360,8 +360,11 @@ export function buildSettingsRows(
       id: "auditorAllowedExtensions",
       section: "auditor",
       label: "Allowed extensions",
+      // Count only — resolved install paths are long absolute strings; joining
+      // them into VALUE expands compact-mode valueW past the terminal width and
+      // crashes pi's TUI. Open the row to pick concrete specs in the picker.
       valueText: settings.auditorAllowedExtensions?.length
-        ? settings.auditorAllowedExtensions.join(", ")
+        ? `${settings.auditorAllowedExtensions.length} enabled`
         : "none (fully isolated, default)",
       sourceText: src("auditorAllowedExtensions"),
       description: "pi extension specs the DETACHED auditor may load (e.g. npm:pi-webaio) so extension-provided model providers can run — tools stay restricted to read/grep/find/ls/bash; empty = the default extension-less auditor",
@@ -688,11 +691,13 @@ export class SettingsMenuComponent implements Component {
     keyW = Math.min(keyW, MAX_KEY_W);
     sourceW = Math.min(sourceW, MAX_SOURCE_W);
     if (!this.showDescriptions) {
-      // With details hidden, give the saved model/thinking value the space
-      // formerly consumed by the hint column. This is the compact/default
-      // view users need to compare a primary with its fallback chain.
+      // With details hidden, give VALUE the space formerly consumed by the
+      // hint column — but NEVER grow past the terminal. Content-driven
+      // valueW (e.g. joined absolute extension paths) used to expand the
+      // grid past width and crash pi (pi-crash.log: terminal 150, line 164).
       const sepW = visibleWidth(COL_SEP);
-      valueW = Math.max(valueW, width - keyW - sourceW - 2 * sepW);
+      const available = Math.max(0, width - keyW - sourceW - 2 * sepW);
+      valueW = available;
       return { keyW, valueW, sourceW, descW: 0 };
     }
     valueW = Math.min(valueW, MAX_VALUE_W);

--- a/tests/glla-table-menu.test.ts
+++ b/tests/glla-table-menu.test.ts
@@ -196,6 +196,37 @@ test("render: compact header row has KEY, VALUE, SOURCE columns", () => {
   assert.doesNotMatch(header, /DESCRIPTION/);
 });
 
+test("render: compact mode never exceeds terminal width even with a long VALUE in another section", () => {
+  // Repro from ~/.pi/agent/pi-crash.log (2026-08-23): terminal 150, settings
+  // header visible width 164. Compact mode sized VALUE from the longest
+  // valueText across ALL sections (joined absolute extension paths), so even
+  // the Keep-going tab overflowed and crashed pi. Include a production-length
+  // KEY so keyW hits MAX_KEY_W (32) — short labels alone leave enough leftover
+  // columns for a ~114-char path to fit without overflowing.
+  const longPath =
+    "/home/samed.guest/.pi/agent/npm/node_modules/pi-cursor-sdk, /home/samed.guest/.pi/agent/npm/node_modules/pi-webaio";
+  assert.ok(longPath.length > 100, "fixture must be long enough to overflow a 150-col terminal");
+  const rows: SettingsRow[] = [
+    { id: "autoResume", section: "keep-going", label: "Auto-resume on load", valueText: "default", sourceText: "default", description: "short" },
+    { id: "subagentFallbacks:general-purpose", section: "subagents", label: "general-purpose fallback agents", valueText: "none", sourceText: "default", description: "short" },
+    {
+      id: "auditorAllowedExtensions",
+      section: "auditor",
+      label: "Allowed extensions",
+      valueText: longPath,
+      sourceText: "global",
+      description: "long absolute paths",
+    },
+  ];
+  const { component } = makeComponent(rows, 150);
+  const width = 150;
+  const lines = component.render(width);
+  for (let i = 0; i < lines.length; i++) {
+    const w = visibleWidthFromTui(lines[i]!);
+    assert.ok(w <= width, `line ${i} visible width ${w} exceeds terminal ${width}: ${lines[i]}`);
+  }
+});
+
 test("render: footer pin includes the optional details toggle", () => {
   const { component } = makeComponent(SAMPLE_ROWS, 120);
   const lines = component.render(120);

--- a/tests/settings-menu-complete.test.ts
+++ b/tests/settings-menu-complete.test.ts
@@ -243,6 +243,30 @@ test("main fallback row shows the persisted numbered try order and truthful runt
   assert.doesNotMatch(row.description, /account\/plan\/billing\/auth|request-rate/);
 });
 
+test("auditorAllowedExtensions valueText is a count — never joined absolute paths (screen-size crash)", () => {
+  // Absolute install paths from discovery are long enough that joining them
+  // into VALUE expands compact-mode valueW past the terminal width and
+  // crashes pi's TUI. The row must show a short count; the picker still
+  // lists the concrete specs when the user opens the editor.
+  const longPaths = [
+    "/home/user/.pi/agent/extensions/npm/node_modules/pi-webaio/index.ts",
+    "/home/user/.pi/agent/extensions/git/some-org/very-long-repo-name/extension.ts",
+    "/opt/shared/pi-extensions/another-provider/dist/index.js",
+  ];
+  const rows = buildSettingsRows(
+    { auditorAllowedExtensions: longPaths } as Settings,
+    { auditorAllowedExtensions: "global" },
+  );
+  const row = rows.find((r) => r.id === "auditorAllowedExtensions")!;
+  assert.equal(row.valueText, "3 enabled");
+  for (const p of longPaths) {
+    assert.doesNotMatch(row.valueText, new RegExp(p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  const empty = buildSettingsRows({} as Settings, EMPTY_PROV)
+    .find((r) => r.id === "auditorAllowedExtensions")!;
+  assert.equal(empty.valueText, "none (fully isolated, default)");
+});
+
 test("valueText derives from settings (effective values surface for each row)", () => {
   const rows = buildSettingsRows(SAMPLE_SETTINGS, provFromSettings(SAMPLE_SETTINGS));
   const byId = new Map<string, SettingsRow>(rows.map((r) => [r.id, r]));

--- a/tests/settings-menu-complete.test.ts
+++ b/tests/settings-menu-complete.test.ts
@@ -255,7 +255,7 @@ test("auditorAllowedExtensions valueText is a count — never joined absolute pa
   ];
   const rows = buildSettingsRows(
     { auditorAllowedExtensions: longPaths } as Settings,
-    { auditorAllowedExtensions: "global" },
+    { auditorAllowedExtensions: { value: longPaths, source: "global" } },
   );
   const row = rows.find((r) => r.id === "auditorAllowedExtensions")!;
   assert.equal(row.valueText, "3 enabled");


### PR DESCRIPTION
## Summary
- Show `N enabled` for Allowed extensions instead of joining absolute install paths in the settings VALUE column (those paths blew past the terminal and crashed pi — see `pi-crash.log`: width 164 on a 150-col terminal).
- Cap compact-mode VALUE width to the available terminal space so a long value in any section cannot overflow other tabs.
- Keep the multi-select picker unchanged so extensions remain selectable when the row is opened.

## Test plan
- [ ] Open `/glla` → Auditor with one or more allowed extensions set; confirm VALUE shows `N enabled` and the menu does not crash
- [ ] Enter the Allowed extensions row; confirm paths/labels still appear and can be toggled/saved
- [ ] `bun test tests/glla-table-menu.test.ts tests/settings-menu-complete.test.ts tests/auditor-extensions.test.ts`