### PR TITLE
fix(auditor): launch worker with a JavaScript runtime

### DIFF
--- a/extensions/goal-loop-auditor-process.ts
+++ b/extensions/goal-loop-auditor-process.ts
@@ -568,7 +568,7 @@ interface AuditorProgressFile {
 export type AuditorInfrastructureClass = "no-verdict" | "timeout" | "transport" | "provider";
 
 export interface AuditorProcessRuntime {
-  /** Override the worker launcher command (normally process.execPath). */
+  /** Override the worker launcher command (normally resolved from process.execPath, with fallback to 'node' for compiled binaries). */
   command?: string;
   /** Override the worker module (normally scripts/goal-auditor-worker.mjs). */
   workerPath?: string;
@@ -756,6 +756,18 @@ function stampToken<T extends GoalAuditorResult>(result: T, capturedToken: GoalR
   return { ...result, goalRevision: capturedToken };
 }
 
+/** Resolve the command to launch the auditor worker child process.
+ * When the current process's execPath is a recognised JavaScript runtime
+ * (node, nodejs, bun, deno) use it directly. Otherwise fall back to 'node'
+ * to handle compiled standalone binaries (e.g. pkg-bundled pi) where
+ * process.execPath returns the binary path, not a JS runtime. */
+export function resolveWorkerCommand(execPath: string): string {
+  const base = path.basename(execPath.replace(/\\/g, "/")).replace(/\.exe$/i, "").toLowerCase();
+  const jsRuntimes = new Set(["node", "nodejs", "bun", "deno"]);
+  if (jsRuntimes.has(base)) return execPath;
+  return "node";
+}
+
 /**
  * Run one completion audit in a detached, extension-less child process.
  * Infrastructure failures never become semantic disapprovals and never fall
@@ -875,7 +887,7 @@ export async function runDetachedGoalCompletionAuditor(args: {
     args.onProgress?.(asProgress(initialProgress, startedAt));
 
     const workerPath = runtime.workerPath ?? defaultWorkerPath();
-    const command = runtime.command ?? process.execPath;
+    const command = runtime.command ?? resolveWorkerCommand(process.execPath);
     const spawn = runtime.spawn ?? nodeSpawn;
     const env = { ...process.env, ...(runtime.env ?? {}) };
     if (runtime.piBinary) env.GLLA_PI_BINARY = runtime.piBinary;

--- a/tests/auditor-process.test.ts
+++ b/tests/auditor-process.test.ts
@@ -11,6 +11,7 @@ import {
   newDetachedAuditJobAttemptId,
   AUDITOR_TOOLS,
   requestHash,
+  resolveWorkerCommand,
   runDetachedGoalCompletionAuditor,
   stableJson,
   type AuditorModel,
@@ -763,7 +764,7 @@ test("detached worker treats silent provider time as infrastructure, not a verdi
   const dir = await mkdtemp(path.join(tmpdir(), "glla-stall-"));
   const fakePi = path.join(dir, "silent-pi.mjs");
   const reports: AuditorProgress[] = [];
-  await writeFile(fakePi, "#!/usr/bin/env node\\nprocess.stdin.resume(); setInterval(() => {}, 1000);\\n");
+  await writeFile(fakePi, "#!/usr/bin/env node\nprocess.stdin.resume(); setInterval(() => {}, 1000);\n");
   await chmod(fakePi, 0o700);
   try {
     const result = await runDetachedGoalCompletionAuditor({
@@ -1228,4 +1229,55 @@ test("v0.36.0: a malformed allowedExtensions request fails closed as an identity
     await stopTestProcess(child);
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("v0.35.60: resolveWorkerCommand falls back from compiled-binary execPath to a JS runtime", () => {
+  // Known JS runtimes return their own path unchanged
+  assert.equal(
+    resolveWorkerCommand("/usr/local/bin/node"),
+    "/usr/local/bin/node",
+  );
+  assert.equal(
+    resolveWorkerCommand("/home/user/.nvm/versions/node/v22.19.0/bin/node"),
+    "/home/user/.nvm/versions/node/v22.19.0/bin/node",
+  );
+  assert.equal(
+    resolveWorkerCommand("/usr/local/bin/bun"),
+    "/usr/local/bin/bun",
+  );
+  assert.equal(
+    resolveWorkerCommand("/usr/local/bin/deno"),
+    "/usr/local/bin/deno",
+  );
+
+  // Windows JS runtime paths
+  assert.equal(
+    resolveWorkerCommand("C:\\nodejs\\node.exe"),
+    "C:\\nodejs\\node.exe",
+  );
+
+  // Non-JS-runtime paths (compiled binaries) fall back to 'node'
+  assert.equal(
+    resolveWorkerCommand("/Users/juanjosegongi/.local/share/mise/installs/pi/0.84.2/pi/pi"),
+    "node",
+  );
+  assert.equal(
+    resolveWorkerCommand("/usr/local/bin/pi"),
+    "node",
+  );
+  assert.equal(
+    resolveWorkerCommand("C:\\Program Files\\Pi\\pi.exe"),
+    "node",
+  );
+  // Also covers bare name (no directory)
+  assert.equal(
+    resolveWorkerCommand("pi"),
+    "node",
+  );
+
+  // nodejs alias should also resolve its own path
+  assert.equal(
+    resolveWorkerCommand("/usr/bin/nodejs"),
+    "/usr/bin/nodejs",
+  );
 });


### PR DESCRIPTION
Closes #23

## Summary

* Resolve the detached auditor worker command from `process.execPath`.
* Preserve Node, Node.js, Bun, Deno, and explicit `runtime.command` launchers.
* Fall back to `node` when Pi runs as a compiled executable.
* Add regression coverage for Unix, Windows, and compiled Pi style paths.
* Correct the silent-provider fixture so it contains real newlines and executes as intended.

## Changes

| File | Change |
| --- | --- |
| `extensions/goal-loop-auditor-process.ts` | Select a JavaScript runtime instead of launching the worker with an arbitrary compiled host executable. |
| `tests/auditor-process.test.ts` | Cover runtime resolution and repair the malformed executable fixture. |

## Test plan

* [x] `bun test tests/auditor-process.test.ts`: 32 passed, 0 failed
* [x] Focused runtime-resolution test: 1 passed, 0 failed
* [x] `npm run check`
* [x] `npm run test:jiti`: 1 passed, 0 failed
* [x] `npm pack --dry-run`
* [x] Reliability review: no actionable findings

The full repository run reached 1572 passing tests and 3 unrelated environment-dependent failures. Two failures assume a case-sensitive filesystem. One reads a local Pi package setting in a shape the test does not support.
