### PR TITLE
Treat prompt-policy refusals as a terminal main-model outcome

### DIFF
--- a/extensions/loops/goal-orchestrator.ts
+++ b/extensions/loops/goal-orchestrator.ts
@@ -167,6 +167,7 @@ import {
   setLastContinuationSentPayloadRef,
   setContinuationRearmStreak,
   setContinuationRearmSince,
+  resetContinuationDispatchState,
   type ContinuationFlags,
   type ContinuationDeps,
 } from "../goal-continuation.js";
@@ -547,6 +548,44 @@ function scheduleProviderRetryForSession(
 // wiring lives at createGoalRecovery(...) below.
 // ============================================================================
 
+/** Prompt-policy refusals own this agent_end. Mirror abortZombieRun's
+ * no-auto-retry park: reset dispatch, reassert stand-down, persist a
+ * restart-safe error pause (or stop a live loop) with no resume time,
+ * then abort the active turn at most once. Do not schedule recovery. */
+function settlePromptPolicyRejection(ctx: ExtensionContext, failure: MainModelFailure): void {
+  const diagnostic = failure.raw;
+  clearMainModelRecoveryTimer();
+  state.mainModelRecovery = undefined;
+  lastMainModelFailure = null;
+  cancelProviderRetry();
+  resetContinuationDispatchState(ctx.cwd);
+  setContinuationDispatchStoodDownRef(true);
+  abortedStandDown = true;
+  clearLoopTimer();
+  const reason = "provider rejected the prompt as a policy violation — automatic retry cannot succeed";
+  const action = `The work is saved. ${activeGoalSurfaceCommand("resume")} retries with a changed prompt; ${activeGoalSurfaceCommand("cancel")} discards it.`;
+  if (state.goal && state.goal.status !== "complete" && state.goal.status !== "aborted") {
+    updateGoal({
+      status: "paused",
+      pauseKind: "error",
+      pauseResumeAt: undefined,
+      pauseReason: reason,
+      pauseSuggestedAction: action,
+      providerErrorDiagnostic: diagnostic,
+    }, ctx);
+  } else if (isLoopActive()) {
+    state.loop = { ...state.loop!, active: false, stopReason: reason };
+    persistState(ctx);
+  } else {
+    persistState(ctx);
+  }
+  if (!mainModelAbortForRecovery) {
+    mainModelAbortForRecovery = true;
+    try { ctx.abort(); } catch { /* ownership flag prevents a second abort */ }
+  }
+  appendLedger(ctx.cwd, "main_model_prompt_policy_terminal", { model: modelRef(ctx.model) });
+}
+
 /** Handle a provider error before loop/goal bookkeeping can mistake it for
  * an unproductive turn. Returns true when recovery owns this agent_end. */
 async function handleMainModelAgentEnd(ctx: ExtensionContext, rawLastA: any, lastA: any): Promise<boolean> {
@@ -558,6 +597,10 @@ async function handleMainModelAgentEnd(ctx: ExtensionContext, rawLastA: any, las
   if (lastA?.stopReason === "error") {
     const rawError = normalizeProviderErrorText(rawLastA, lastA.text);
     const failure = classifyMainModelFailure(rawError);
+    if (failure.nonRecoverableReason === "prompt-policy") {
+      settlePromptPolicyRejection(ctx, failure);
+      return true;
+    }
     lastMainModelFailure = failure;
     if (failure.kind !== "non-recoverable") {
       const switched = await tryMainModelFallback(ctx, failure);

--- a/extensions/loops/goal-session.ts
+++ b/extensions/loops/goal-session.ts
@@ -1094,6 +1094,9 @@ export function __testOnlyResetTerminalFlags(): void {
   staleContinuationRearmPending = false;
   zombieStoodDown = false;
   sessionHandoffPending = false;
+  mainModelAbortForRecovery = false;
+  lastMainModelFailure = null;
+  abortedStandDown = false;
 }
 
 /** TEST-ONLY hook (tests/harness): set/clear the persisted lastModelRef

--- a/extensions/main-model-recovery.ts
+++ b/extensions/main-model-recovery.ts
@@ -36,6 +36,8 @@ export type MainModelFailureKind = "rate-limit" | "quota" | "billing" | "auth" |
 export interface MainModelFailure {
   kind: MainModelFailureKind;
   raw: string;
+  /** Set only for deterministic prompt-policy / content-filter refusals. */
+  nonRecoverableReason?: "prompt-policy";
   /** Legacy provider-hint fields are accepted by old callers only; the
    * classifier and retry policy never populate or consult them. */
   retryAfterSec?: number;
@@ -110,6 +112,39 @@ export function formatMainModelFallbacks(value: unknown): string {
 }
 
 /**
+ * Deterministic prompt-policy / content-filter refusals. Retrying the same
+ * payload cannot heal them. Keep this narrower than generic provider
+ * failures: rate limits, first-token timeouts, overloads, ordinary 403/500,
+ * bare "policy" / "prompt-policy" tokens, project-policy prose, and stray
+ * "invalid prompt" mentions stay recoverable.
+ *
+ * Verified evidence form (anchored): `Codex error event: invalid prompt`.
+ * Adjacent terminal markers: content_filter / prompt_filter / safety_filter,
+ * content/safety/usage/responsible-AI policy violation, prompt blocked,
+ * prompt/request + flagged/blocked/rejected/refused/violation in a
+ * content-safety / filter / usage-policy context (either order), and
+ * wrapped 403/500 payloads that carry those same refusal markers.
+ */
+export function isPromptPolicyRejection(error: string | undefined): boolean {
+  const raw = typeof error === "string" ? error.trim() : "";
+  if (!raw) return false;
+  if (/^codex error event:\s*invalid prompt\b/i.test(raw)) return true;
+  if (/\b(?:content_filter|prompt_filter|safety_filter)\b/i.test(raw)) return true;
+  if (/\bprompt blocked\b/i.test(raw)) return true;
+  if (/\b(?:content|safety|usage|responsible[-_ ]ai)[-_ ]policy[-_ ]violation\b/i.test(raw)) return true;
+  if (/\b(?:content|safety|usage|responsible[-_ ]ai)[-_ ]policy\s+violation\b/i.test(raw)) return true;
+  const subject = /\b(?:prompt|request)\b/i.test(raw);
+  const verdict = /\b(?:flagged|blocked|reject(?:ed|ion)?|refus(?:ed|al)|violation|violating)\b/i.test(raw);
+  const safety = /\b(?:content[- ]safety|usage[- ]policy|content[_ ]filter|safety[_ ]filter|prompt[_ ]filter|responsible[-_ ]ai)\b/i.test(raw);
+  if (subject && verdict && safety) return true;
+  if (/\b(?:http\s*)?(?:403|500)\b/i.test(raw)) {
+    if (/\b(?:content_filter|prompt_filter|safety_filter|prompt blocked)\b/i.test(raw)) return true;
+    if (/\b(?:content|safety|usage|responsible[-_ ]ai)[-_ ]policy\b/i.test(raw) && verdict) return true;
+  }
+  return false;
+}
+
+/**
  * Classify only provider failures. Context/output-token failures are
  * deterministic prompt-shape problems and must not trigger model rotation.
  *
@@ -134,6 +169,9 @@ export function classifyMainModelFailure(error: string | undefined, opts?: { isC
   }
   if (/^(?:auditor aborted\.?$|user (?:interrupt|abort)|cancelled by user)/i.test(raw) || /user interrupt/.test(text)) {
     return { kind: "non-recoverable", raw };
+  }
+  if (isPromptPolicyRejection(raw)) {
+    return { kind: "non-recoverable", raw, nonRecoverableReason: "prompt-policy" };
   }
   if (/context|output[ -]?token|max_?tokens|length limit|too many tokens|prompt too large|context window/.test(text)) {
     return opts?.isContextOverflow

--- a/tests/behavioral-orchestrator.test.ts
+++ b/tests/behavioral-orchestrator.test.ts
@@ -19,7 +19,8 @@
 // cwd's .pi-glla, so tests stay independent despite shared module state.
 
 import { resetLengthContinue } from "../extensions/length-continue.js";
-import { resetContinuationDispatchState, clearContinuationTimer } from "../extensions/goal-continuation.js";
+import { resetContinuationDispatchState, clearContinuationTimer, continuationDispatchStoodDownRef, continuationTimerPending, pendingContinuationDispatchRef } from "../extensions/goal-continuation.js";
+import { isProviderRetryPending } from "../extensions/quota-retry.js";
 import { test, afterEach } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -2421,6 +2422,93 @@ test("recoverable error turns enter generic recovery before stall accounting", a
   assert.equal(snapshot.goal.pauseKind, "wait");
   assert.match(snapshot.goal.pauseReason ?? "", /main model recovery/);
   assert.ok(snapshot.mainModelRecovery, "the retry plan is durable before stall accounting");
+});
+
+test("prompt-policy rejection is terminal: no retry, no wait, no continuation, abort once", async () => {
+  __testOnlyResetStaleFlag();
+  __testOnlyResetTerminalFlags();
+  const cwd = tmpCwd();
+  const ctx = await freshSession(cwd, "startup");
+  let aborts = 0;
+  const previousAbort = ctx.abort.bind(ctx);
+  let observedActiveOnAbort = false;
+  ctx.abort = () => {
+    aborts++;
+    const during = readState(cwd).goal as { status?: string } | null;
+    if (during?.status === "active") observedActiveOnAbort = true;
+    previousAbort();
+  };
+  await pi.command("goal", "start prompt-policy terminal target — done when pinned", ctx);
+  await tick();
+  const sentBefore = pi.sent.length;
+  try {
+    await pi.fire("agent_end", {
+      messages: [{ role: "assistant", content: [], stopReason: "error", errorMessage: "Codex error event: invalid prompt" }],
+    }, ctx);
+    await tick();
+    await pi.fire("agent_settled", {}, ctx);
+    await tick(400);
+    const snapshot = readState(cwd) as {
+      goal?: {
+        status?: string;
+        pauseKind?: string;
+        pauseReason?: string;
+        pauseResumeAt?: string;
+        providerErrorDiagnostic?: string;
+      };
+      mainModelRecovery?: { retryAt?: string };
+    };
+    assert.equal(snapshot.mainModelRecovery, undefined, "must not park durable recovery");
+    assert.equal(snapshot.goal?.status, "paused", "terminal rejection pauses the goal");
+    assert.equal(snapshot.goal?.pauseKind, "error", "error pause, not a recovery wait");
+    assert.equal(snapshot.goal?.pauseResumeAt, undefined, "no auto-resume time");
+    assert.match(snapshot.goal?.pauseReason ?? "", /policy violation/);
+    assert.doesNotMatch(snapshot.goal?.pauseReason ?? "", /Codex|invalid prompt/i, "raw provider text is not the pause reason");
+    assert.match(snapshot.goal?.providerErrorDiagnostic ?? "", /Codex error event: invalid prompt/, "raw text stays diagnostic-only");
+    const ledger = fs.readFileSync(path.join(cwd, ".pi-glla", "active.jsonl"), "utf8");
+    assert.ok(ledger.includes("main_model_prompt_policy_terminal"), "terminal outcome ledgered");
+    assert.equal(ledger.includes("main_model_recovery_wait"), false, "no recovery wait");
+    assert.equal(isProviderRetryPending(), false, "provider retry cancelled");
+    assert.equal(pendingContinuationDispatchRef(), null, "dispatch artifacts reset");
+    assert.equal(continuationTimerPending(), false, "continuation timer cancelled");
+    assert.equal(continuationDispatchStoodDownRef(), true, "stand-down reasserted after reset");
+    assert.equal(aborts, 1, "active turn aborted exactly once");
+    assert.equal(observedActiveOnAbort, false, "abort must not observe an active goal");
+    assert.equal(pi.sent.length, sentBefore, "no follow-up turn dispatched");
+
+    __testOnlyLoadState(cwd);
+    const reloaded = readState(cwd).goal as {
+      status?: string;
+      pauseKind?: string;
+      pauseResumeAt?: string;
+      pauseReason?: string;
+      providerErrorDiagnostic?: string;
+    };
+    assert.equal(reloaded.status, "paused", "reload keeps the error pause");
+    assert.equal(reloaded.pauseKind, "error");
+    assert.equal(reloaded.pauseResumeAt, undefined);
+    assert.doesNotMatch(reloaded.pauseReason ?? "", /Codex|invalid prompt/i);
+    assert.match(reloaded.providerErrorDiagnostic ?? "", /Codex error event: invalid prompt/);
+  } finally {
+    resetContinuationDispatchState(cwd);
+    __testOnlyResetTerminalFlags();
+  }
+});
+
+test("transient overload still schedules main-model recovery", async () => {
+  __testOnlyResetStaleFlag();
+  const cwd = tmpCwd();
+  const ctx = await freshSession(cwd, "startup");
+  await pi.command("goal", "start transient overload recovery target — done when pinned", ctx);
+  await tick();
+  await pi.fire("agent_end", {
+    messages: [{ role: "assistant", content: [], stopReason: "error", errorMessage: "503 upstream overloaded" }],
+  }, ctx);
+  await tick();
+  const snapshot = readState(cwd) as { goal: { status: string; pauseKind?: string }; mainModelRecovery?: { retryAt?: string } };
+  assert.equal(snapshot.goal.status, "paused");
+  assert.equal(snapshot.goal.pauseKind, "wait");
+  assert.ok(snapshot.mainModelRecovery?.retryAt, "transient overload still schedules recovery");
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/tests/main-model-recovery.test.ts
+++ b/tests/main-model-recovery.test.ts
@@ -10,6 +10,8 @@ import {
   classifyMainModelFailure,
   isMainModelFallbackFailure,
   isMainModelFailbackAuto,
+  isPromptPolicyRejection,
+  requiresMainModelRecovery,
   mainModelAutoRetryUntil,
   mainModelFailureDelayMs,
   mainModelPrimaryProbeDelayMs,
@@ -317,6 +319,57 @@ test("in-band provider output is recognized only for strong repeated-pane marker
   assert.equal(classifyInBandProviderFailure("HTTP 503 upstream unavailable")?.kind, "transient");
   assert.ok(classifyInBandProviderFailure("HTTP 429 Too Many Requests"), "429 remains recoverable even when the generic classifier stays opaque");
   assert.equal(classifyInBandProviderFailure("network_error: fetch failed")?.kind, "transient");
+});
+
+test("prompt-policy rejections are a narrow terminal main-model class", () => {
+  for (const raw of [
+    "Codex error event: invalid prompt",
+    "Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt",
+    "content_filter",
+    "prompt_filter: blocked",
+    "safety_filter triggered",
+    "content_policy_violation",
+    "usage policy violation",
+    "safety policy violation",
+    "prompt blocked",
+    "The prompt was rejected due to content safety",
+    "request refused by the usage policy",
+    "HTTP 403 content_filter",
+    "500 prompt blocked",
+  ]) {
+    assert.equal(isPromptPolicyRejection(raw), true, raw);
+    const failure = classifyMainModelFailure(raw);
+    assert.equal(failure.kind, "non-recoverable", raw);
+    assert.equal(failure.nonRecoverableReason, "prompt-policy", raw);
+    assert.equal(requiresMainModelRecovery(failure), false, raw);
+    assert.equal(isMainModelFallbackFailure(failure), false, raw);
+  }
+});
+
+test("bare policy tokens, stray invalid-prompt, and transient failures stay recoverable", () => {
+  for (const raw of [
+    "prompt-policy",
+    "project-policy: use bun test",
+    "project-policy violation",
+    "invalid prompt",
+    "invalid_prompt",
+    "the policy is documented in AGENTS.md",
+    "HTTP 403 forbidden",
+    "HTTP 500 upstream",
+    "503 temporarily unavailable",
+    "first-token timeout",
+    "HTTP 429 Too Many Requests",
+    "rate limit reached",
+    "mysterious provider prose with no hint",
+  ]) {
+    assert.equal(isPromptPolicyRejection(raw), false, raw);
+    const failure = classifyMainModelFailure(raw);
+    assert.notEqual(failure.nonRecoverableReason, "prompt-policy", raw);
+    assert.equal(requiresMainModelRecovery(failure), true, raw);
+    assert.equal(isMainModelFallbackFailure(failure), true, raw);
+  }
+  assert.equal(classifyMainModelFailure("user aborted").nonRecoverableReason, undefined);
+  assert.equal(classifyMainModelFailure("max_tokens exceeds context window").nonRecoverableReason, undefined);
 });
 
 test("main model errors stay opaque to the recovery policy", () => {

--- a/tests/prompt-policy-terminal.test.ts
+++ b/tests/prompt-policy-terminal.test.ts
@@ -1,0 +1,61 @@
+// Focused prompt-policy regression. Uses only classifyMainModelFailure /
+// requiresMainModelRecovery / isMainModelFallbackFailure so a git-archive
+// snapshot of origin/main can run it without the later helper export.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  classifyMainModelFailure,
+  isMainModelFallbackFailure,
+  requiresMainModelRecovery,
+} from "../extensions/main-model-recovery.js";
+
+const TERMINAL = [
+  "Codex error event: invalid prompt",
+  "Invalid prompt: your prompt was flagged as potentially violating our usage policy. Please try again with a different prompt",
+  "content_filter",
+  "prompt_filter: blocked",
+  "safety_filter triggered",
+  "content_policy_violation",
+  "usage policy violation",
+  "safety policy violation",
+  "prompt blocked",
+  "The prompt was rejected due to content safety",
+  "request refused by the usage policy",
+  "HTTP 403 content_filter",
+  "500 prompt blocked",
+];
+
+const RECOVERABLE = [
+  "prompt-policy",
+  "project-policy: use bun test",
+  "project-policy violation",
+  "invalid prompt",
+  "invalid_prompt",
+  "the policy is documented in AGENTS.md",
+  "HTTP 403 forbidden",
+  "HTTP 500 upstream",
+  "503 temporarily unavailable",
+  "first-token timeout",
+  "HTTP 429 Too Many Requests",
+  "rate limit reached",
+  "mysterious provider prose with no hint",
+];
+
+test("verified prompt-policy refusals are non-recoverable and skip main-model recovery", () => {
+  for (const raw of TERMINAL) {
+    const failure = classifyMainModelFailure(raw);
+    assert.equal(failure.kind, "non-recoverable", raw);
+    assert.equal(failure.nonRecoverableReason, "prompt-policy", raw);
+    assert.equal(requiresMainModelRecovery(failure), false, raw);
+    assert.equal(isMainModelFallbackFailure(failure), false, raw);
+  }
+});
+
+test("project-policy, stray invalid-prompt, and ordinary provider failures stay recoverable", () => {
+  for (const raw of RECOVERABLE) {
+    const failure = classifyMainModelFailure(raw);
+    assert.notEqual(failure.nonRecoverableReason, "prompt-policy", raw);
+    assert.equal(requiresMainModelRecovery(failure), true, raw);
+    assert.equal(isMainModelFallbackFailure(failure), true, raw);
+  }
+});


### PR DESCRIPTION
## Summary
- Treat verified Codex invalid-prompt and content/safety/usage/responsible-AI refusals as a terminal main-model class (`nonRecoverableReason: "prompt-policy"`).
- Persist a restart-safe `pauseKind: "error"` park (or stop an active loop) with no auto-retry **before** aborting the turn exactly once; clear `lastMainModelFailure` so later lifecycle cannot re-park recovery.
- Leave ordinary 403/500, stray `invalid prompt`, bare `prompt-policy`, and `project-policy violation` on the existing recovery envelope.

## Inbox 008–013 (acknowledged)
008 pre-fix archive proof; 009 abortZombieRun no-auto-retry subset; 010 persist-before-abort + narrowed classifier; 011 flagged usage-policy positive + clear `lastMainModelFailure`; 012 test-only global reset; 013 stop-before-push. 014 isolated the baseline/environment failures; the approved contributor-fork delivery then opened this PR.

## CI
GitGuardian passed. The upstream `Publish npm package` workflow requires maintainer approval for this first-time fork and has not run.

## Test plan
- [x] Focused: `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/prompt-policy-terminal.test.ts tests/main-model-recovery.test.ts tests/context-overflow-recovery.test.ts` → 21 pass
- [x] Focused: `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/behavioral-orchestrator.test.ts` → 120 pass (includes prompt-policy terminal park)
- [x] `npx tsc --noEmit` / `npm run check` → pass
- [x] `node tests/repro-jiti-state-split.test.mjs` → pass
- [x] `npm run test:auditor-extensions` → pass
- [x] `git diff --check origin/main...HEAD` → clean
- [x] Lint: **none**. `package.json` has no lint script; no eslint/biome/oxlint/prettier config; CI `quality` job runs `npm run release:check` only.
- [x] Pre-fix proof (008): `git archive origin/main` snapshot + copy `tests/prompt-policy-terminal.test.ts` + reuse `node_modules` (no install). `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/prompt-policy-terminal.test.ts` → fail (`Codex error event: invalid prompt` classified `unknown`). Same command on this branch → 2 pass.
- [ ] Do not treat `npm run test:all` as green on this copy.

### Full-suite isolation (014) — do not rerun `test:all`
One bounded `npm run test:all` was 1648 pass / 1 skip / 6 fail / 1 error. Each distinct cause was re-run once on **HEAD `5d8bc23c`** and on an unchanged **`git archive origin/main` (`0438246c`)** snapshot with the same reused `node_modules`. All six reproduce on origin/main. None are in this diff.

| Cause | Exact command | HEAD | origin/main snapshot | Classification |
| --- | --- | --- | --- | --- |
| APFS `spec.md`/`SPEC.md` case-fold | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/loop-forever.test.ts -t "resolveSpecFile: spec.md fallback"` | fail: actual `SPEC.md` vs expected `spec.md` | same fail | environment (case-insensitive FS) |
| APFS `spec.md`/`SPEC.md` case-fold | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/loop-forever.test.ts -t "resolveSpecFiles: returns all root specs"` | fail: extra `SPEC.md` entry after writing `spec.md` | same fail | environment (case-insensitive FS) |
| Missing optional `@tintinweb/pi-subagents` | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/subagent-model-override.test.ts -t "drift: embedded Explore"` | fail: drift guard source required | same fail | missing optional install (`node_modules/@tintinweb/pi-subagents` absent; not installed per copy rules) |
| Live-rig host settings | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/command-registration-collisions.test.ts -t "live rig — the routing table"` | fail: `source.startsWith` TypeError (`~/.pi/agent` present so skip is off; `packages` includes a non-string object entry) | same fail | host fixture (`PI_CODING_AGENT_DIR` / `~/.pi/agent/settings.json`) |
| Silent fake-pi spawn | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/auditor-process.test.ts -t "detached worker treats silent provider time"` | fail: `ENOEXEC posix_spawn .../silent-pi.mjs` instead of `Auditor stalled` | same fail | environment/fixture (macOS spawn of the test's fake `silent-pi.mjs`) |
| Missing optional module | `bun test --parallel=1 --max-concurrency=1 --timeout=60000 tests/subagent-stop-rpc.integration.test.mjs` | fail+error: `Cannot find module '../node_modules/@tintinweb/pi-subagents/src/agent-manager.js'` | same fail+error | missing optional install (same package as drift) |

`npm pack --dry-run` previously succeeded; it is **not** a full-suite pass.
