### PR TITLE
fix: preserve detached auditor exit diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   state. It reacts to lifecycle/durable signals immediately and uses adaptive
   fallback polling rather than guessed task-duration waits.
 
+### Fixed
+  Detached completion-auditor failures now coordinate RPC stdout EOF with the
+  child process close, preserving bounded exit code, signal, stderr, and
+  malformed-stream diagnostics while remaining fail-closed until
+  `agent_settled`.
+
 ### Changed
   Aggressive recovery retries recoverable provider/host/auditor failures across
   arbitrary durations with bounded per-attempt backoff. Ordinary auditor

--- a/scripts/goal-auditor-worker.mjs
+++ b/scripts/goal-auditor-worker.mjs
@@ -26,6 +26,11 @@ const DEFAULT_TOOL_TIMEOUT_MS = 5 * 60_000;
 // kill and destroy the pipes so this worker can finish and exit too.
 const DEFAULT_CHILD_SHUTDOWN_GRACE_MS = 1_000;
 const FORCE_KILL_SETTLE_MS = 250;
+// stdout EOF normally precedes ChildProcess `close`. Give the child a short
+// window to report its real exit code/signal and drain stderr before publishing
+// a no-verdict result. A child that closes stdout but remains alive is still
+// bounded: the same worker-owned TERM→KILL cleanup runs when this grace ends.
+const DEFAULT_RPC_CLOSE_GRACE_MS = 250;
 
 function configuredDuration(name, fallback) {
   const value = Number(process.env[name] ?? fallback);
@@ -406,6 +411,7 @@ async function main() {
   let streamError;
   let pi;
   let inactivityTimer;
+  let rpcCloseGraceTimer;
   // `lastActivityAt` is user-visible and must remain unset until a real RPC
   // event arrives. The separate probe clock keeps the inactivity brake armed
   // while the provider is silent during startup/thinking.
@@ -460,6 +466,7 @@ async function main() {
     // without changing the exact result output used for verdict parsing.
     appendRecentOutput(recentOutput, recentReportLine, "", true);
     if (inactivityTimer) clearInterval(inactivityTimer);
+    if (rpcCloseGraceTimer) clearTimeout(rpcCloseGraceTimer);
     for (const timer of toolTimers.values()) clearTimeout(timer);
     toolTimers.clear();
     // Wait for the nested RPC child to settle before publishing the terminal
@@ -567,6 +574,40 @@ async function main() {
     // retry/compact/follow up after it. agent_settled is the completion event.
     let stdoutBuffer = "";
     let settledSeen = false;
+    const RPC_CLOSE_GRACE_MS = configuredDuration("GLLA_AUDITOR_EOF_EXIT_GRACE_MS", DEFAULT_RPC_CLOSE_GRACE_MS);
+    let stdoutEnded = false;
+    let piExited = false;
+    let piClosed = false;
+    let piExitCode;
+    let piExitSignal;
+    let rpcStreamDiagnostic;
+
+    const missingSettledError = (closeGraceExpired = false) => {
+      const processFacts = `pi exited before agent_settled (code=${piExitCode ?? "?"}, signal=${piExitSignal ?? "none"})`;
+      const closeGraceDetail = closeGraceExpired && !piClosed
+        ? `; RPC streams did not close within ${RPC_CLOSE_GRACE_MS}ms`
+        : "";
+      const headline = closeGraceExpired && stdoutEnded && !piExited
+        ? `RPC stdout ended before agent_settled and the child did not close within ${RPC_CLOSE_GRACE_MS}ms`
+        : `${processFacts}${closeGraceDetail}`;
+      return [...new Set([headline, rpcStreamDiagnostic, streamError].filter(Boolean))].join(": ");
+    };
+
+    const coordinatePiEnd = () => {
+      if (finalized || settledSeen) return;
+      if (piClosed) {
+        void finish(false, missingSettledError()).catch(() => {});
+        return;
+      }
+      if ((!stdoutEnded && !piExited) || rpcCloseGraceTimer) return;
+      rpcCloseGraceTimer = setTimeout(() => {
+        rpcCloseGraceTimer = undefined;
+        if (finalized || settledSeen || piClosed) return;
+        void finish(false, missingSettledError(true)).catch(() => {});
+      }, RPC_CLOSE_GRACE_MS);
+      rpcCloseGraceTimer.unref?.();
+    };
+
     const handleRpcLine = (line) => {
       if (finalized || !line) return;
       // The RPC contract is LF-delimited but permits a trailing CR for
@@ -688,11 +729,11 @@ async function main() {
     });
     pi.stdout.on("end", () => {
       if (finalized) return;
+      stdoutEnded = true;
       if (stdoutBuffer.length > 0) {
-        void finish(false, "RPC stream ended with an unterminated LF record").catch(() => {});
-      } else if (!settledSeen) {
-        void finish(false, "pi exited without an agent_settled RPC event").catch(() => {});
+        rpcStreamDiagnostic = "RPC stream ended with an unterminated LF record";
       }
+      coordinatePiEnd();
     });
 
     pi.stderr.on("data", (chunk) => {
@@ -714,10 +755,17 @@ async function main() {
     pi.stderr.on("error", (error) => handlePiStreamError("stderr", error));
     pi.on("error", (error) => { void finish(false, `pi launch failed: ${error.message}`).catch(() => {}); });
     pi.on("exit", (code, signal) => {
-      if (!finalized) {
-        const detail = streamError ? `: ${streamError}` : "";
-        void finish(false, `pi exited before audit completion (code=${code ?? "?"}, signal=${signal ?? "?"})${detail}`).catch(() => {});
-      }
+      piExited = true;
+      piExitCode = code;
+      piExitSignal = signal;
+      coordinatePiEnd();
+    });
+    pi.on("close", (code, signal) => {
+      piClosed = true;
+      piExited = true;
+      piExitCode = code;
+      piExitSignal = signal;
+      coordinatePiEnd();
     });
 
     // Exactly one LF-terminated JSONL prompt. JSON.stringify escapes embedded

--- a/tests/auditor-process.test.ts
+++ b/tests/auditor-process.test.ts
@@ -744,12 +744,25 @@ test("request hashing is stable and excludes no runtime secret or API key field"
   assert.equal("apiKey" in request, false);
 });
 
-test("an early RPC child exit still publishes an atomic infrastructure result", async () => {
+test("EOF before exit preserves process and stream diagnostics without accepting a partial verdict", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "glla-early-rpc-exit-"));
   const fakePi = path.join(dir, "early-exit-pi.mjs");
+  const attemptLog = path.join(dir, "pi-attempts.log");
+  const pidMarker = path.join(dir, "pi-pid");
   await writeFile(fakePi, `#!/usr/bin/env node
-process.stdin.destroy();
-setTimeout(() => process.exit(17), 25);
+import { appendFileSync, writeFileSync } from "node:fs";
+appendFileSync(process.env.PI_ATTEMPT_LOG, String(process.pid) + "\\n");
+writeFileSync(process.env.PI_PID_MARKER, String(process.pid));
+let handled = false;
+process.stdin.on("data", (chunk) => {
+  if (handled || !String(chunk).includes("\\n")) return;
+  handled = true;
+  process.stdout.write(JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "<disapproved/>" } }) + "\\n");
+  process.stderr.write("EOF_EXIT_17_UNIQUE_STDERR\\n");
+  process.stdout.write('{"type":"message_update"');
+  process.stdout.end();
+  setTimeout(() => process.exit(17), 25);
+});
 `);
   await chmod(fakePi, 0o700);
   try {
@@ -760,7 +773,7 @@ setTimeout(() => process.exit(17), 25);
       thinkingLevel: "high",
       runtime: {
         workerPath: path.resolve(process.cwd(), "scripts/goal-auditor-worker.mjs"),
-        env: { GLLA_PI_BINARY: fakePi },
+        env: { GLLA_PI_BINARY: fakePi, PI_ATTEMPT_LOG: attemptLog, PI_PID_MARKER: pidMarker },
         attemptId: () => "attempt-early-rpc-exit",
         pollIntervalMs: 10,
         wallTimeoutMs: 10_000,
@@ -768,9 +781,71 @@ setTimeout(() => process.exit(17), 25);
     });
     assert.equal(result.approved, false);
     assert.equal(result.disapproved, false);
-    assert.match(result.error ?? "", /RPC stdin stream failed|pi exited before audit completion|pi exited without an agent_settled|RPC stream ended/);
+    assert.equal(result.output, "<disapproved/>", "partial semantic text remains diagnostic-only output");
+    assert.match(result.error ?? "", /pi exited before agent_settled \(code=17, signal=none\)/);
+    assert.match(result.error ?? "", /RPC stream ended with an unterminated LF record/);
+    assert.match(result.error ?? "", /EOF_EXIT_17_UNIQUE_STDERR/);
+    assert.doesNotMatch(result.error ?? "", /^pi exited without an agent_settled RPC event$/);
     assert.doesNotMatch(result.error ?? "", /worker exited without an atomic result/);
     assert.equal(result.infrastructureClass, "no-verdict", "a worker that exits before a verdict is no-verdict infrastructure");
+    const attempts = (await readFile(attemptLog, "utf8")).trim().split("\n").filter(Boolean);
+    assert.equal(attempts.length, 1, "one detached attempt produces one infrastructure result");
+    const piPid = Number(await readFile(pidMarker, "utf8"));
+    assert.throws(() => process.kill(piPid, 0), /ESRCH|不存在|not found/i, "the exited RPC child is reaped before return");
+    assert.deepEqual(await readdir(path.join(dir, ".pi-glla", "audit-jobs")), [], "the single attempt's scratch and result are removed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("EOF from a live RPC child gets a bounded close grace then TERM-to-KILL cleanup", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "glla-live-after-eof-"));
+  const fakePi = path.join(dir, "live-after-eof-pi.mjs");
+  const pidMarker = path.join(dir, "pi-pid");
+  const sigtermMarker = path.join(dir, "pi-sigterm");
+  await writeFile(fakePi, `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+writeFileSync(process.env.PI_PID_MARKER, String(process.pid));
+process.on("SIGTERM", () => { writeFileSync(process.env.PI_SIGTERM_MARKER, "received"); });
+let handled = false;
+process.stdin.on("data", (chunk) => {
+  if (handled || !String(chunk).includes("\\n")) return;
+  handled = true;
+  process.stderr.write("EOF_LIVE_UNIQUE_STDERR\\n");
+  process.stdout.end();
+});
+setInterval(() => {}, 1_000);
+`);
+  await chmod(fakePi, 0o700);
+  try {
+    const result = await runDetachedGoalCompletionAuditor({
+      cwd: dir,
+      goal,
+      model: "test/provider-model",
+      thinkingLevel: "high",
+      runtime: {
+        workerPath: path.resolve(process.cwd(), "scripts/goal-auditor-worker.mjs"),
+        env: {
+          GLLA_PI_BINARY: fakePi,
+          GLLA_AUDITOR_EOF_EXIT_GRACE_MS: "80",
+          GLLA_AUDITOR_CHILD_SHUTDOWN_MS: "80",
+          PI_PID_MARKER: pidMarker,
+          PI_SIGTERM_MARKER: sigtermMarker,
+        },
+        attemptId: () => "attempt-live-after-eof",
+        pollIntervalMs: 10,
+        wallTimeoutMs: 10_000,
+      },
+    });
+    assert.equal(result.approved, false);
+    assert.equal(result.disapproved, false);
+    assert.equal(result.infrastructureClass, "no-verdict");
+    assert.match(result.error ?? "", /RPC stdout ended before agent_settled and the child did not close within 80ms/);
+    assert.match(result.error ?? "", /EOF_LIVE_UNIQUE_STDERR/);
+    assert.ok(existsSync(sigtermMarker), "the existing cooperative TERM cleanup runs after the EOF grace");
+    const piPid = Number(await readFile(pidMarker, "utf8"));
+    assert.throws(() => process.kill(piPid, 0), /ESRCH|不存在|not found/i, "the TERM-ignoring child is force-killed before return");
+    assert.deepEqual(await readdir(path.join(dir, ".pi-glla", "audit-jobs")), [], "the grace failure leaves no job scratch");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -780,7 +855,10 @@ test("detached worker treats silent provider time as infrastructure, not a verdi
   const dir = await mkdtemp(path.join(tmpdir(), "glla-stall-"));
   const fakePi = path.join(dir, "silent-pi.mjs");
   const reports: AuditorProgress[] = [];
-  await writeFile(fakePi, "#!/usr/bin/env node\\nprocess.stdin.resume(); setInterval(() => {}, 1000);\\n");
+  await writeFile(fakePi, `#!/usr/bin/env node
+process.stdin.resume();
+setInterval(() => {}, 1_000);
+`);
   await chmod(fakePi, 0o700);
   try {
     const result = await runDetachedGoalCompletionAuditor({


### PR DESCRIPTION
## Summary

- Coordinate detached Pi RPC stdout EOF with child exit/close before publishing a no-verdict result.
- Preserve bounded exit code, signal, stderr, and unterminated-stream diagnostics.
- Bound an EOF-with-live-child case with a short grace followed by the existing TERM-to-KILL cleanup.
- Keep `agent_settled` as the only semantic-success boundary. `agent_end`, EOF, process exit, provider errors, and partial verdict markers remain infrastructure-only.

## Cause and safety

The worker previously finalized immediately when stdout ended. When EOF arrived before the child exit event, that generic result masked the real Pi exit code, signal, and captured stderr. The parent already handled the result fail-closed, retried only within its existing bounded policy, and cleaned up the detached worker; those parent semantics are unchanged.

The exact historical Pi-side trigger cannot be recovered because the old worker discarded these diagnostics and the parent removed completed job scratch. This change makes the next occurrence actionable without reinterpreting infrastructure failure as approval or disapproval.

## Regression coverage

- Deterministic EOF-before-exit case emits partial `<disapproved/>`, a unique stderr marker, an unterminated RPC record, and exit 17. The test asserts both verdict flags remain false, class `no-verdict`, exit/stderr/stream facts survive, exactly one attempt runs, scratch is removed, and the process is dead.
- EOF-with-live-child case asserts the close grace expires, cooperative TERM is attempted, the TERM-ignoring child is force-killed, and no job scratch remains.
- Existing semantic-verdict, provider-error, exact RPC-contract, and wedged-child controls remain green.
- The silent-provider fixture now uses a physical multiline executable so its intended timeout control runs on macOS instead of failing at `posix_spawn` with `ENOEXEC`.

## Verification

- `bun test tests/auditor-process.test.ts`: 32 pass, 0 fail.
- `npm run check`: pass.
- `npm run test:jiti`: 1 pass, 0 fail.
- `npm run test:auditor-extensions`: pass offline; one fixture model registered and no temporary extension install created.
- `npm run lint --if-present`: pass; no lint script is configured.
- `npm pack --dry-run --json --ignore-scripts`: pass, 81 entries.
- `git diff --check origin/main...HEAD`: pass.
- Full available suite was run and is **not claimed green**: 1,686 pass, 1 skip, and 5 unrelated local-environment failures. Those outcomes are the two known case-insensitive `SPEC.md`/`spec.md` fixture failures, the unavailable exact `@tintinweb/pi-subagents@0.15.0` drift/module fixtures, and the no-git-repository fixture observing the enclosing worktree because safety kept `TMPDIR` inside this checkout. The task-owned auditor suite is independently 32/32 green.

## Protected state and scope

The sorted manifest of all 103 protected `.pi-glla/` and `audit/` files remains unchanged at `58bf481ee9c5391931bedfaddb904f296108ed4db59170bf5f28311f1b0e0057`. Installed GLLA/hotfix files, real goal/fleet state, archived goal `20260826045613-b5b2kd`, ignored reproduction evidence, and prompt-policy PR #37 were not modified. No package was installed.
