### PR TITLE
fix(tui): truncate picker and settings titles to terminal width

### DIFF
--- a/extensions/model-picker.ts
+++ b/extensions/model-picker.ts
@@ -210,7 +210,7 @@ export class ModelPickerComponent {
   render(width: number): string[] {
     const w = Math.max(20, width - 2);
     const lines: string[] = [];
-    lines.push(this.theme.fg("accent", this.theme.bold(this.title)));
+    lines.push(this.theme.fg("accent", this.theme.bold(truncateToWidth(this.title, w, "…"))));
     lines.push("");
     const searchLine = `search: ${this.query}`;
     lines.push(this.theme.fg("muted", truncateToWidth(searchLine, w, "…") + "▏"));

--- a/extensions/multi-model-picker.ts
+++ b/extensions/multi-model-picker.ts
@@ -322,7 +322,7 @@ export class MultiModelPickerComponent {
   render(width: number): string[] {
     const w = Math.max(20, width - 2);
     const lines: string[] = [];
-    lines.push(this.theme.fg("accent", this.theme.bold(this.title)));
+    lines.push(this.theme.fg("accent", this.theme.bold(truncateToWidth(this.title, w, "…"))));
     if (this.unorderedSet) {
       lines.push(this.theme.fg("muted", "selected extensions are loaded by the auditor; order does not matter:"));
     } else if (this.currentRef) {

--- a/extensions/settings-menu.ts
+++ b/extensions/settings-menu.ts
@@ -778,7 +778,7 @@ export class SettingsMenuComponent implements Component {
 
     const lines: string[] = [];
 
-    lines.push(this.theme.fg("accent", this.theme.bold(this.title)));
+    lines.push(this.theme.fg("accent", this.theme.bold(truncateToWidth(this.title, Math.max(20, width - 2), "…"))));
 
     // v0.28.19: color-only tabs (user call: "dropping the brackets") —
     // active = accent + bold, inactive = dim. No bracket chrome.

--- a/tests/multi-model-picker.test.ts
+++ b/tests/multi-model-picker.test.ts
@@ -12,6 +12,8 @@
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 
+import { visibleWidth } from "@earendil-works/pi-tui";
+
 import { buildModelPickItems } from "../extensions/model-picker.ts";
 import { MultiModelPickerComponent, type MultiModelPickerResult } from "../extensions/multi-model-picker.ts";
 
@@ -319,6 +321,32 @@ test("multi-model-picker: order mode — empty chain is a no-op and esc still ca
   assert.deepEqual(p.comp.getSelected(), []);
   p.comp.handleInput("\x1b");
   assert.equal(p.result, undefined, "esc cancels even from order mode");
+});
+
+test("multi-model-picker: render truncates a long title to the terminal width", () => {
+  // Regression: untruncated titles (main/auditor fallback help text) crashed
+  // pi with "Rendered line N exceeds terminal width".
+  const longTitle =
+    "Main agent fallback models — try order is current → fallback 1 → fallback 2 … (space add/remove, tab order mode with ↑/↓, enter save); forbidden models are skipped";
+  const items = buildModelPickItems(MODELS, "minimax/MiniMax-M3");
+  const p = new MultiModelPickerComponent(
+    { title: longTitle, items, currentRef: "minimax/MiniMax-M3" },
+    () => undefined,
+    THEME,
+    KB,
+    () => undefined,
+  );
+  const width = 140;
+  const lines = p.render(width);
+  for (const line of lines) {
+    assert.ok(
+      visibleWidth(line) <= width,
+      `line exceeds width ${width}: visible=${visibleWidth(line)} text=${JSON.stringify(line)}`,
+    );
+  }
+  assert.match(lines[0]!, /Main agent fallback models/);
+  assert.match(lines[0]!, /…/);
+  assert.ok(!lines[0]!.includes("forbidden models are skipped"), "trailing help text is truncated");
 });
 
 test("multi-model-picker: order mode — the active chain row is highlighted and the footer switches", () => {


### PR DESCRIPTION
## Summary
- Truncate titles in `MultiModelPicker`, `ModelPicker`, and the settings menu with `truncateToWidth`, matching how picker rows already truncate.
- Prevents pi from crashing with `Rendered line N exceeds terminal width` when opening Main/Auditor fallback models (long help titles exceeded a 140-col terminal).
- Adds a regression test that renders the real fallback-models title at width 140.

## Test plan
- [x] `node --test tests/multi-model-picker.test.ts` (30 pass)
- [x] Manually open Main agent fallback models in pi and confirm the picker opens without crashing
- [ ] Open Auditor fallback models at a narrow terminal width and confirm the title truncates cleanly