### PR TITLE
fix: keep loop checkpoint byte-stable across iterations (prefix-cache stability)

### DIFF
--- a/extensions/context-checkpoint.ts
+++ b/extensions/context-checkpoint.ts
@@ -78,26 +78,28 @@ function loopNumber(value: unknown): string {
 
 /**
  * The loop is a separate work surface from Goal. Keep its durable target and
- * progress in the checkpoint so a loop-only session does not lose its
- * authority when old goal-event payloads are projected out. Recent history is
- * useful for orientation, but is deliberately capped and treated as data.
+ * authority in the checkpoint so a loop-only session does not lose its
+ * context when old goal-event payloads are projected out.
+ *
+ * CACHE-STABILITY INVARIANT (provider prefix-cache rule): this checkpoint is
+ * inserted into the effective per-send message list at the position of the
+ * first removed goal-event payload — i.e. EARLY in history, before every
+ * provider call. Any byte change here invalidates the cache prefix for every
+ * token after it. This block therefore renders ONLY fields that are stable
+ * for the life of the loop run (target / measure / bounds config). Live
+ * counters (iteration, best, last, stall, tokens, history, timestamps) are
+ * intentionally NOT repeated here: they already ride the newest retained
+ * `[LOOP ITERATION …]` prompt (message-list suffix) and durable
+ * `.pi-glla/active.jsonl`. Rendering them here changed the prefix on every
+ * tick, making every loop iteration a full cache miss.
  */
 function loopCheckpointLines(loop: LoopState): string[] {
-  const history = Array.isArray(loop.history) ? loop.history : [];
-  const recentHistory = history.slice(-8).map((entry) =>
-    `iteration=${loopNumber(entry.iteration)}, value=${entry.value === null ? "null" : loopNumber(entry.value)}, improved=${entry.improved === true ? "true" : "false"}, at=${safeInline(entry.at, 80) || "(unknown)"}`,
-  );
-  if (history.length > recentHistory.length) {
-    recentHistory.unshift(`[…${history.length - recentHistory.length} earlier loop measurement(s) omitted]`);
-  }
   return [
     "Active loop authority (durable loop state; not a user request):",
     `Loop target: ${safeInline(loop.target, 2_000) || "(missing — recover from durable loop state before proceeding)"}`,
     `Loop measure: command=${safeInline(loop.measureCmd, 1_200) || "(metricless)"}; direction=${safeInline(loop.direction, 20) || "(none)"}`,
-    `Loop progress: active=${loop.active === true ? "true" : "false"}; iteration=${loopNumber(loop.iteration)}; best=${loopNumber(loop.bestValue)}; last=${loopNumber(loop.lastValue)}; stall=${loopNumber(loop.stallCount)}; nullMeasures=${loopNumber(loop.consecutiveNullMeasures)}; errors=${loopNumber(loop.consecutiveErrors)}`,
-    `Loop bounds: maxIterations=${loopNumber(loop.maxIterations)}; plateauWindow=${loopNumber(loop.plateauWindow)}; timeLimitHours=${loopNumber(loop.timeLimitHours)}; tokenBudget=${loopNumber(loop.tokenBudget)}; tokensUsed=${loopNumber(loop.tokensUsed)}; stopReason=${safeInline(loop.stopReason, 400) || "(none)"}`,
-    `Loop history (latest ${Math.min(history.length, 8)} of ${history.length}):\n${recentHistory.length > 0 ? recentHistory.join("\n") : "(none yet)"}`,
-    `Loop lifecycle: startedAt=${safeInline(loop.startedAt, 100) || "(unknown)"}; lastIterationCompletedAt=${safeInline(loop.lastIterationCompletedAt, 100) || "(none)"}; specFile=${safeInline(loop.specFile, 300) || "(none)"}; refineHint=${safeInline(loop.refineHint, 600) || "(none)"}`,
+    `Loop bounds: maxIterations=${loopNumber(loop.maxIterations)}; plateauWindow=${loopNumber(loop.plateauWindow)}; timeLimitHours=${loopNumber(loop.timeLimitHours)}; tokenBudget=${loopNumber(loop.tokenBudget)}; specFile=${safeInline(loop.specFile, 300) || "(none)"}; startedAt=${safeInline(loop.startedAt, 100) || "(unknown)"}`,
+    "Loop progress: live counters (iteration/best/last/stall/history/tokens/completed-at) are intentionally omitted here — read the newest retained [LOOP ITERATION …] prompt and .pi-glla/active.jsonl. This checkpoint stays byte-stable across iterations so provider prefix caches keep hitting.",
   ];
 }
 
@@ -146,15 +148,13 @@ const OVERFLOW_AUDIT_CHARS = 1_100;
 const OVERFLOW_EMERGENCY_LINE_CHARS = 500;
 
 function compactLoopCheckpointLines(loop: LoopState): string[] {
-  const historyCount = Array.isArray(loop.history) ? loop.history.length : 0;
-  const latest = historyCount > 0 ? loop.history[historyCount - 1] : undefined;
+  // Same cache-stability invariant as loopCheckpointLines: stable fields only.
   return [
     "Active loop authority (durable loop state; not a user request):",
     `Loop target: ${safeInline(loop.target, OVERFLOW_LOOP_TARGET_CHARS) || "(missing — recover from durable loop state before proceeding)"}`,
     `Loop measure: command=${safeInline(loop.measureCmd, OVERFLOW_LOOP_MEASURE_CHARS) || "(metricless)"}; direction=${safeInline(loop.direction, 20) || "(none)"}`,
-    `Loop progress: active=${loop.active === true ? "true" : "false"}; iteration=${loopNumber(loop.iteration)}; best=${loopNumber(loop.bestValue)}; last=${loopNumber(loop.lastValue)}; stall=${loopNumber(loop.stallCount)}; nullMeasures=${loopNumber(loop.consecutiveNullMeasures)}; errors=${loopNumber(loop.consecutiveErrors)}`,
-    `Loop bounds: maxIterations=${loopNumber(loop.maxIterations)}; plateauWindow=${loopNumber(loop.plateauWindow)}; timeLimitHours=${loopNumber(loop.timeLimitHours)}; tokenBudget=${loopNumber(loop.tokenBudget)}; tokensUsed=${loopNumber(loop.tokensUsed)}; stopReason=${safeInline(loop.stopReason, 180) || "(none)"}`,
-    `Loop lifecycle: startedAt=${safeInline(loop.startedAt, 70) || "(unknown)"}; lastIterationCompletedAt=${safeInline(loop.lastIterationCompletedAt, 70) || "(none)"}; specFile=${safeInline(loop.specFile, 160) || "(none)"}; historyCount=${historyCount}; latestIteration=${latest ? loopNumber(latest.iteration) : "(none)"}`,
+    `Loop bounds: maxIterations=${loopNumber(loop.maxIterations)}; plateauWindow=${loopNumber(loop.plateauWindow)}; timeLimitHours=${loopNumber(loop.timeLimitHours)}; tokenBudget=${loopNumber(loop.tokenBudget)}; specFile=${safeInline(loop.specFile, 160) || "(none)"}`,
+    "Loop progress: live counters omitted by design — see the newest retained loop prompt and .pi-glla/active.jsonl (keeps this checkpoint byte-stable for prefix-cache stability).",
   ];
 }
 
@@ -212,7 +212,7 @@ function buildOverflowCheckpoint(
 
   const optionalLines = [
     loop
-      ? `Loop history summary: count=${Array.isArray(loop.history) ? loop.history.length : 0}; latest=${Array.isArray(loop.history) && loop.history.length > 0 ? loopNumber(loop.history[loop.history.length - 1]?.value) : "(none)"}`
+      ? "Loop history summary: omitted by design — live history rides the newest retained loop prompt (keeps this checkpoint byte-stable for prefix-cache stability)"
       : null,
     goal
       ? `Auto-continuation: ${goal.autoContinue === true ? "enabled" : "disabled/unknown"}; stopReason=${safeInline(goal.stopReason, 220) || "(none)"}; pauseKind=${safeInline(goal.pauseKind, 40) || "(none)"}`

--- a/tests/context-checkpoint.test.ts
+++ b/tests/context-checkpoint.test.ts
@@ -207,7 +207,13 @@ test("loop-only projection bounds repeated payloads and carries loop authority",
   assert.match(checkpoint, /loopTarget=Bound loop-only continuation context/);
   assert.match(checkpoint, /Loop target: Bound loop-only continuation context/);
   assert.match(checkpoint, /Loop measure: command=printf 17/);
-  assert.match(checkpoint, /iteration=4/);
+  assert.match(checkpoint, /Loop bounds: maxIterations=50/);
+  // Cache-stability invariant: volatile loop counters must NOT be rendered
+  // into the checkpoint (it sits early in the per-send history, so any byte
+  // change busts the provider prefix cache for every later token).
+  assert.ok(!/iteration=4/.test(checkpoint), "checkpoint must not render live iteration");
+  assert.ok(!/best=17/.test(checkpoint), "checkpoint must not render live best value");
+  assert.ok(!/stall=1/.test(checkpoint), "checkpoint must not render live stall count");
 
   const messages = [
     { role: "user", content: "ordinary context" },
@@ -228,6 +234,37 @@ test("loop-only projection bounds repeated payloads and carries loop authority",
   assert.equal(after.messageCount, 3);
   assert.equal(after.gllaMessageCount, 2);
   assert.ok(after.serializedBytes < before.serializedBytes);
+});
+
+test("loop checkpoint is byte-stable across volatile loop progress (prefix-cache stability)", () => {
+  const base = loopFixture();
+  const next: LoopState = {
+    ...base,
+    iteration: 5,
+    stallCount: 2,
+    bestValue: 17,
+    lastValue: 21,
+    consecutiveNullMeasures: 1,
+    consecutiveErrors: 1,
+    tokensUsed: 9_000,
+    lastIterationCompletedAt: "2026-08-29T10:04:00.000Z",
+    refineHint: "try a different angle",
+    history: [
+      ...base.history,
+      { iteration: 4, value: 21, improved: false, at: "2026-08-29T10:04:00.000Z" },
+      { iteration: 5, value: null, improved: false, at: "2026-08-29T10:05:00.000Z" },
+    ],
+  };
+  const input = { goal: null, sessionGeneration: 13, ownerSessionId: "loop-owner-13" } as const;
+  const before = buildAuthoritativeContextCheckpoint({ ...input, loop: base });
+  const after = buildAuthoritativeContextCheckpoint({ ...input, loop: next });
+  assert.equal(after, before, "volatile loop counters must not change checkpoint bytes — the checkpoint is inserted early in history and any change busts the provider prefix cache for every later token");
+  // Stable authority must still move the checkpoint when it genuinely changes.
+  const retargeted = buildAuthoritativeContextCheckpoint({
+    ...input,
+    loop: { ...base, target: "a different loop target" },
+  });
+  assert.notEqual(retargeted, before);
 });
 
 test("context hook projects loop-only state and records loop authority", async () => {


### PR DESCRIPTION
## Symptom

With an active `/loop`, every iteration is a full prompt-cache miss: `cacheReadTokens` collapses from the 2nd iteration on, so each tick re-bills the whole context. Repro: start any loop, run 2+ iterations, compare `context_usage_sample.cacheReadTokens` in `.pi-glla/active.jsonl` before/after.

## Root cause

`pi.on("context", …)` (`extensions/loops/goal-activation.ts`) rewrites the effective per-send message list before every provider call via `projectBoundedGllaContext()`: old `goal-event` payloads are deleted from the middle of history and one fresh authoritative checkpoint is inserted at the first removed position — i.e. early in history.

Provider prompt caches are prefix-based, and the checkpoint rendered live loop counters (`iteration / best / last / stall / nullMeasures / errors / tokensUsed / 8-entry history tail / lastIterationCompletedAt / refineHint / stopReason`). So from iteration 2 on (`DEFAULT_MAX_RETAINED_GLLA_PAYLOADS = 1` means the projection fires on every tick), the prefix diverged at the checkpoint on every send — a structurally guaranteed full-context miss.

## Fix (`extensions/context-checkpoint.ts` only)

The loop section of the checkpoint now renders only run-stable fields (target / measure command+direction / bounds config / specFile / startedAt) plus a pointer line to the live data. The removed counters already exist in two fresher places, so nothing the model needs is lost: the newest retained `[LOOP ITERATION …]` prompt (message-list suffix) carries iteration/best/last/stall/tokens, and durable `.pi-glla/active.jsonl` plus the `loop_measured` ledger carry full history; `refineHint` is one-shot and rides the next prompt's `REFINE_HINT` slot. Goal section, projection mechanics and overflow required-field reservations are untouched.

## Tests

Updated `tests/context-checkpoint.test.ts` (replaced the `/iteration=4/` assertion that pinned the cache-busting behavior) and added regression test `loop checkpoint is byte-stable across volatile loop progress`. `bun test tests/context-checkpoint.test.ts`: 11 pass / 0 fail; `tsc --noEmit`: clean.
